### PR TITLE
Color-blind friendly visual documentation

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -37,7 +37,7 @@ settings. Leave these blanks to use the theme colors for built-in search command
 
 ## Color Blind Friendliness
 
-By defaul the colors used for visual documentation are selected to be color-blind friendly (by consistently varying the luminance of the colors). You can set `colorBlindDocs` to false if you'd like to use a palette that is not color-blind friendly. There are slightly more distinct shades that can be used in this case (8 instead of 6).
+By defaul the colors used for visual documentation are selected to be color-blind friendly (by consistently varying the luminance of the colors). You can set `colorBlindDocs` to false if you'd like to use a palette that is not color-blind friendly. There are slightly more distinct shades that can be used in this case (8 instead of 5).
 
 ## Changing Status Bar
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -35,6 +35,10 @@ settings. Leave these blanks to use the theme colors for built-in search command
 | `searchOtherMatchesBackground` | ``      | Background color for other visible search matches.
 | `searchOtherMatchesBorder`     | ``      | Border color for other visible search matches .
 
+## Color Blind Friendliness
+
+By defaul the colors used for visual documentation are selected to be color-blind friendly (by consistently varying the luminance of the colors). You can set `colorBlindDocs` to false if you'd like to use a palette that is not color-blind friendly. There are slightly more distinct shades that can be used in this case (8 instead of 6).
+
 ## Changing Status Bar
 
 You can change the text shown in status bar in each mode along with the text

--- a/docs/key_forms.md
+++ b/docs/key_forms.md
@@ -181,7 +181,9 @@ keybindings: {
 }
 ```
 
-The colors for doc kinds are determined by their order in `docKinds`, and are selected from a carefully defined [color brewer](https://colorbrewer2.org/#type=sequential&scheme=BuGn&n=3) color set, to ensure colors are easily differentiable.
+The colors for doc kinds are determined by their order in `docKinds`, and are selected from a carefully defined [Batlow](https://www.fabiocrameri.ch/batlow/) color scheme. There are 5 such colors, and they are chosen to be friendly to color-blind viewers by consistently varying the luminance. You can also [switch](./config.html#color-blind-friendliness) to a more vibrant [color brewer](https://colorbrewer2.org/#type=sequential&scheme=BuGn&n=3) set, which has 8 distinct colors. This set is not as accessable to color-blind viewers. 
+
+If you have more kinds than avaialble colors in your documentation, the colors will be cycled (i.e. the 6th kind will be colored the same as the 1st if you use the color-blind friendly option).
 
 ### Leaders
 

--- a/docview/script.js
+++ b/docview/script.js
@@ -111,7 +111,20 @@ const allKeys = [
     "space"
 ]
 
-function setColor(element, kind){
+function findColor(kind, config){
+    if(!kind){
+        return 'kind-color-none'
+    }
+    if(config.colorCblind){
+        let i = (kind.index) % 5
+        return `kind-color-blind-${i}`
+    }else{
+        let i = (kind.index) % 8
+        return `kind-color-${i}`
+    }
+}
+
+function setColor(element, kind, config){
     let oldcolor = undefined
     for(let className of element.classList.values()){
         if(className.match(/kind-color/)){
@@ -120,7 +133,7 @@ function setColor(element, kind){
         }
     }
     if(oldcolor){ element.classList.remove(oldcolor) }
-    element.classList.add(`kind-color-${kind ? kind.index : 'none'}`)
+    element.classList.add(findColor(kind, config))
 }
 function capitalizeFirstLetter(string) {
     return string.charAt(0).toUpperCase() + string.slice(1);
@@ -130,6 +143,7 @@ window.addEventListener('message', event => {
     const message = event.data;
     let keymap = message.keymap;
     let kinds = message.kinds;
+    let config = message.config;
 
     // update keys
     for(i in allKeys){
@@ -139,11 +153,11 @@ window.addEventListener('message', event => {
         if(keymap && keymap[names[i]]){
             let binding = keymap[names[i]]
             name.innerHTML = binding.label
-            let kind_d = (kinds && kinds[binding.kind]) || {index: 'none', description: ''}
+            let kind_d = (kinds && kinds[binding.kind]) || {index: 'none', description: '', colorBlind: false}
             detail.innerHTML = `
                 <div class="detail-text">
                     ${binding.kind ?
-                        `${capitalizeFirstLetter(binding.kind)} command (<div class="detail-kind-color kind-color-${kind_d.index}"></div>): `
+                        `${capitalizeFirstLetter(binding.kind)} command (<div class="detail-kind-color kind-color-${findColor(kind_d, config)}"></div>): `
                     : ''}
                     ${binding.detail}
                 </div>
@@ -151,8 +165,8 @@ window.addEventListener('message', event => {
             `
             detail.classList.remove('empty')
             if(kinds){
-                setColor(name, kinds[binding.kind])
-                setColor(label, kinds[binding.kind])
+                setColor(name, kinds[binding.kind], config)
+                setColor(label, kinds[binding.kind], config)
             }
         }else{
             if(detail){ 

--- a/docview/script.js
+++ b/docview/script.js
@@ -115,7 +115,7 @@ function findColor(kind, config){
     if(!kind){
         return 'kind-color-none'
     }
-    if(config.colorCblind){
+    if(config.colorBlind){
         let i = (kind.index) % 5
         return `kind-color-blind-${i}`
     }else{
@@ -157,7 +157,7 @@ window.addEventListener('message', event => {
             detail.innerHTML = `
                 <div class="detail-text">
                     ${binding.kind ?
-                        `${capitalizeFirstLetter(binding.kind)} command (<div class="detail-kind-color kind-color-${findColor(kind_d, config)}"></div>): `
+                        `${capitalizeFirstLetter(binding.kind)} command (<div class="detail-kind-color ${findColor(kind_d, config)}"></div>): `
                     : ''}
                     ${binding.detail}
                 </div>

--- a/docview/style.css
+++ b/docview/style.css
@@ -14,6 +14,12 @@
 .kind-color-6 { background-color: #a6761d77; }
 .kind-color-7 { background-color: #66666677; }
 
+.kind-color-blind-0 { background-color: #31685B; }
+.kind-color-blind-1 { background-color: #577647; }
+.kind-color-blind-2 { background-color: #818232; }
+.kind-color-blind-3 { background-color: #B38E2F; }
+.kind-color-blind-4 { background-color: #E19652; }
+
 .detail-kind-color {
     min-width: 1.5rem;
     width: 1rem;

--- a/docview/style.css
+++ b/docview/style.css
@@ -14,11 +14,11 @@
 .kind-color-6 { background-color: #a6761d77; }
 .kind-color-7 { background-color: #66666677; }
 
-.kind-color-blind-0 { background-color: #31685B; }
-.kind-color-blind-1 { background-color: #577647; }
-.kind-color-blind-2 { background-color: #818232; }
-.kind-color-blind-3 { background-color: #B38E2F; }
-.kind-color-blind-4 { background-color: #E19652; }
+.kind-color-blind-0 { background-color: #31685Baa; }
+.kind-color-blind-1 { background-color: #577647aa; }
+.kind-color-blind-2 { background-color: #818232aa; }
+.kind-color-blind-3 { background-color: #B38E2Faa; }
+.kind-color-blind-4 { background-color: #E19652aa; }
 
 .detail-kind-color {
     min-width: 1.5rem;

--- a/package.json
+++ b/package.json
@@ -138,6 +138,11 @@
                         }
                     }
                 },
+                "modalkeys.colorBlindDocs": {
+                    "type": "boolean",
+                    "default": "false",
+                    "description": "Use shades that vary in luminance as well as color to make visual documentation of keybindings accessible to those with limited color vision. This reduces the number of disintct colors that are used."
+                },
                 "modalkeys.userPresetsFolder": {
                     "type": "string",
                     "description": "A folder where modal-key presets can be found.",

--- a/src/keymap.ts
+++ b/src/keymap.ts
@@ -98,10 +98,12 @@ interface MappedKeyKind {
     description?: string
 }
 let docKinds: IHash<MappedKeyKind> | undefined
+let useColorBlind = false
 export function updateFromConfig(): void {
     const config = vscode.workspace.getConfiguration("modalkeys")
     let kinds = config.get<KeyKind[]>("docKinds", []);
     docKinds = {}
+    useColorBlind = config.get<boolean>("colorBlindDocs", false);
     for(let i=0; i<kinds.length; i++){
         docKinds[kinds[i].name] = {index: i, description: kinds[i].description}
     }
@@ -135,7 +137,11 @@ export class DocViewProvider implements vscode.WebviewViewProvider {
 
     public refresh(){
         if(this._view?.webview){
-            this._view?.webview.postMessage({keymap: this._help_map, kinds: docKinds})
+            this._view?.webview.postMessage({
+                keymap: this._help_map, 
+                kinds: docKinds,
+                config: {colorBlind: useColorBlind}
+            })
         }
     }
     public updateStatic(mode: string){


### PR DESCRIPTION
Use batlow color scheme to make colors accessable, by default.