### PR TITLE
WIP: tool-tip display in activity bar

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -20,7 +20,7 @@
 		},
 		{
 			"name": "Run Web Extension in VS Code",
-			"type": "pwa-extensionHost",
+			"type": "extensionHost",
 			"debugWebWorkerHost": true,
 			"request": "launch",
 			"args": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the ModalKeys extension will be documented in this file.
 
+# Version 0.11.0
+- **Feature**: Suport for keybinding tips (shown in activity bar) via
+`docTips` configuration key. See documetnation for details.
+- **Bugfix**: fix bug that lead to rare merging of documentation entries 
+(when key was the same but mode was different)
+
 # Version 0.10.4
 - **Bugfix**: fix bug in 'd' command in `larkin.js` caused by recent fixes to
 `modalkeys.enterNormal`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-modal-keys",
-    "version": "0.10.0",
+    "version": "0.10.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-modal-keys",
-            "version": "0.10.0",
+            "version": "0.10.4",
             "license": "MIT",
             "dependencies": {
                 "vscode-uri": "^3.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
     "name": "vscode-modal-keys",
-    "version": "0.10.4",
+    "version": "0.11.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-modal-keys",
-            "version": "0.10.4",
+            "version": "0.11.0",
             "license": "MIT",
             "dependencies": {
                 "vscode-uri": "^3.0.3",
-                "webpack-cli": "^4.10.0"
+                "webpack": "^5.73.0",
+                "webpack-cli": "^4.9.2"
             },
             "devDependencies": {
                 "@types/glob": "^7.1.3",
@@ -2148,7 +2149,6 @@
             "version": "8.4.1",
             "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.1.tgz",
             "integrity": "sha512-GE44+DNEyxxh2Kc6ro/VkIj+9ma0pO0bwv9+uHSyBrikYOHr8zYcdPvnBOp1aw8s+CjRvuSx7CyWqRrNFQ59mA==",
-            "peer": true,
             "dependencies": {
                 "@types/estree": "*",
                 "@types/json-schema": "*"
@@ -2158,7 +2158,6 @@
             "version": "3.7.3",
             "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.3.tgz",
             "integrity": "sha512-PB3ldyrcnAicT35TWPs5IcwKD8S333HMaa2VVv4+wdvebJkjWuW/xESoB8IwRcog8HYVYamb1g/R31Qv5Bx03g==",
-            "peer": true,
             "dependencies": {
                 "@types/eslint": "*",
                 "@types/estree": "*"
@@ -2167,8 +2166,7 @@
         "node_modules/@types/estree": {
             "version": "0.0.51",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
-            "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
-            "peer": true
+            "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ=="
         },
         "node_modules/@types/express": {
             "version": "4.17.13",
@@ -2406,7 +2404,6 @@
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
             "integrity": "sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==",
-            "peer": true,
             "dependencies": {
                 "@webassemblyjs/helper-numbers": "1.11.1",
                 "@webassemblyjs/helper-wasm-bytecode": "1.11.1"
@@ -2415,26 +2412,22 @@
         "node_modules/@webassemblyjs/floating-point-hex-parser": {
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz",
-            "integrity": "sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==",
-            "peer": true
+            "integrity": "sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ=="
         },
         "node_modules/@webassemblyjs/helper-api-error": {
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz",
-            "integrity": "sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==",
-            "peer": true
+            "integrity": "sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg=="
         },
         "node_modules/@webassemblyjs/helper-buffer": {
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz",
-            "integrity": "sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==",
-            "peer": true
+            "integrity": "sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA=="
         },
         "node_modules/@webassemblyjs/helper-numbers": {
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz",
             "integrity": "sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==",
-            "peer": true,
             "dependencies": {
                 "@webassemblyjs/floating-point-hex-parser": "1.11.1",
                 "@webassemblyjs/helper-api-error": "1.11.1",
@@ -2444,14 +2437,12 @@
         "node_modules/@webassemblyjs/helper-wasm-bytecode": {
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz",
-            "integrity": "sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==",
-            "peer": true
+            "integrity": "sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q=="
         },
         "node_modules/@webassemblyjs/helper-wasm-section": {
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz",
             "integrity": "sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==",
-            "peer": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.11.1",
                 "@webassemblyjs/helper-buffer": "1.11.1",
@@ -2463,7 +2454,6 @@
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz",
             "integrity": "sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==",
-            "peer": true,
             "dependencies": {
                 "@xtuc/ieee754": "^1.2.0"
             }
@@ -2472,7 +2462,6 @@
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.1.tgz",
             "integrity": "sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==",
-            "peer": true,
             "dependencies": {
                 "@xtuc/long": "4.2.2"
             }
@@ -2480,14 +2469,12 @@
         "node_modules/@webassemblyjs/utf8": {
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.1.tgz",
-            "integrity": "sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==",
-            "peer": true
+            "integrity": "sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ=="
         },
         "node_modules/@webassemblyjs/wasm-edit": {
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz",
             "integrity": "sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==",
-            "peer": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.11.1",
                 "@webassemblyjs/helper-buffer": "1.11.1",
@@ -2503,7 +2490,6 @@
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz",
             "integrity": "sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==",
-            "peer": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.11.1",
                 "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
@@ -2516,7 +2502,6 @@
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz",
             "integrity": "sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==",
-            "peer": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.11.1",
                 "@webassemblyjs/helper-buffer": "1.11.1",
@@ -2528,7 +2513,6 @@
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz",
             "integrity": "sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==",
-            "peer": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.11.1",
                 "@webassemblyjs/helper-api-error": "1.11.1",
@@ -2542,7 +2526,6 @@
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz",
             "integrity": "sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==",
-            "peer": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.11.1",
                 "@xtuc/long": "4.2.2"
@@ -2584,14 +2567,12 @@
         "node_modules/@xtuc/ieee754": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
-            "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
-            "peer": true
+            "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA=="
         },
         "node_modules/@xtuc/long": {
             "version": "4.2.2",
             "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
-            "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
-            "peer": true
+            "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
         },
         "node_modules/abbrev": {
             "version": "1.1.1",
@@ -2670,7 +2651,6 @@
             "version": "3.5.2",
             "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
             "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-            "peer": true,
             "peerDependencies": {
                 "ajv": "^6.9.1"
             }
@@ -5318,8 +5298,7 @@
         "node_modules/es-module-lexer": {
             "version": "0.9.3",
             "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
-            "integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==",
-            "peer": true
+            "integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ=="
         },
         "node_modules/es-to-primitive": {
             "version": "1.2.1",
@@ -6228,8 +6207,7 @@
         "node_modules/glob-to-regexp": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-            "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-            "peer": true
+            "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
         },
         "node_modules/glob2base": {
             "version": "0.0.12",
@@ -7547,7 +7525,6 @@
             "version": "27.4.6",
             "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.4.6.tgz",
             "integrity": "sha512-gHWJF/6Xi5CTG5QCvROr6GcmpIqNYpDJyc8A1h/DyXqH1tD6SnRCM0d3U5msV31D2LB/U+E0M+W4oyvKV44oNw==",
-            "peer": true,
             "dependencies": {
                 "@types/node": "*",
                 "merge-stream": "^2.0.0",
@@ -7561,7 +7538,6 @@
             "version": "8.1.1",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
             "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-            "peer": true,
             "dependencies": {
                 "has-flag": "^4.0.0"
             },
@@ -7773,7 +7749,6 @@
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.2.0.tgz",
             "integrity": "sha512-92+huvxMvYlMzMt0iIOukcwYBFpkYJdpl2xsZ7LrlayO7E8SOv+JJUEK17B/dJIHAOLMfh2dZZ/Y18WgmGtYNw==",
-            "peer": true,
             "engines": {
                 "node": ">=6.11.5"
             }
@@ -8017,8 +7992,7 @@
         "node_modules/merge-stream": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-            "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-            "peer": true
+            "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
         },
         "node_modules/merge2": {
             "version": "1.4.1",
@@ -8373,8 +8347,7 @@
         "node_modules/neo-async": {
             "version": "2.6.2",
             "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-            "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-            "peer": true
+            "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
         },
         "node_modules/nice-try": {
             "version": "1.0.5",
@@ -10737,7 +10710,6 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
             "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
-            "peer": true,
             "dependencies": {
                 "@types/json-schema": "^7.0.8",
                 "ajv": "^6.12.5",
@@ -11785,7 +11757,6 @@
             "version": "5.3.0",
             "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.0.tgz",
             "integrity": "sha512-LPIisi3Ol4chwAaPP8toUJ3L4qCM1G0wao7L3qNv57Drezxj6+VEyySpPw4B1HSO2Eg/hDY/MNF5XihCAoqnsQ==",
-            "peer": true,
             "dependencies": {
                 "jest-worker": "^27.4.1",
                 "schema-utils": "^3.1.1",
@@ -11832,7 +11803,6 @@
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
             "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -11841,7 +11811,6 @@
             "version": "5.10.0",
             "resolved": "https://registry.npmjs.org/terser/-/terser-5.10.0.tgz",
             "integrity": "sha512-AMmF99DMfEDiRJfxfY5jj5wNH/bYO09cniSqhfoyxc8sFoYIgkJy86G04UoZU5VjlpnplVu0K6Tx6E9b5+DlHA==",
-            "peer": true,
             "dependencies": {
                 "commander": "^2.20.0",
                 "source-map": "~0.7.2",
@@ -11866,7 +11835,6 @@
             "version": "0.7.3",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
             "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-            "peer": true,
             "engines": {
                 "node": ">= 8"
             }
@@ -12444,7 +12412,6 @@
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.3.1.tgz",
             "integrity": "sha512-x0t0JuydIo8qCNctdDrn1OzH/qDzk2+rdCOC3YzumZ42fiMqmQ7T3xQurykYMhYfHaPHTp4ZxAx2NfUo1K6QaA==",
-            "peer": true,
             "dependencies": {
                 "glob-to-regexp": "^0.4.1",
                 "graceful-fs": "^4.1.2"
@@ -12472,7 +12439,6 @@
             "version": "5.73.0",
             "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.73.0.tgz",
             "integrity": "sha512-svjudQRPPa0YiOYa2lM/Gacw0r6PvxptHj4FuEKQ2kX05ZLkjbVc5MnPs6its5j7IZljnIqSVo/OsY2X0IpHGA==",
-            "peer": true,
             "dependencies": {
                 "@types/eslint-scope": "^3.7.3",
                 "@types/estree": "^0.0.51",
@@ -12590,7 +12556,6 @@
             "version": "3.2.3",
             "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
             "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
-            "peer": true,
             "engines": {
                 "node": ">=10.13.0"
             }
@@ -12599,7 +12564,6 @@
             "version": "8.7.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
             "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -12611,7 +12575,6 @@
             "version": "1.8.0",
             "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
             "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
-            "peer": true,
             "peerDependencies": {
                 "acorn": "^8"
             }
@@ -12620,7 +12583,6 @@
             "version": "5.9.3",
             "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.9.3.tgz",
             "integrity": "sha512-Bq9VSor+kjvW3f9/MiiR4eE3XYgOl7/rS8lnSxbRbF3kS0B2r+Y9w5krBWxZgDxASVZbdYrn5wT4j/Wb0J9qow==",
-            "peer": true,
             "dependencies": {
                 "graceful-fs": "^4.2.4",
                 "tapable": "^2.2.0"
@@ -12633,7 +12595,6 @@
             "version": "1.51.0",
             "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
             "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==",
-            "peer": true,
             "engines": {
                 "node": ">= 0.6"
             }
@@ -12642,7 +12603,6 @@
             "version": "2.1.34",
             "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
             "integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
-            "peer": true,
             "dependencies": {
                 "mime-db": "1.51.0"
             },
@@ -12654,7 +12614,6 @@
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
             "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
-            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -14374,7 +14333,6 @@
             "version": "8.4.1",
             "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.1.tgz",
             "integrity": "sha512-GE44+DNEyxxh2Kc6ro/VkIj+9ma0pO0bwv9+uHSyBrikYOHr8zYcdPvnBOp1aw8s+CjRvuSx7CyWqRrNFQ59mA==",
-            "peer": true,
             "requires": {
                 "@types/estree": "*",
                 "@types/json-schema": "*"
@@ -14384,7 +14342,6 @@
             "version": "3.7.3",
             "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.3.tgz",
             "integrity": "sha512-PB3ldyrcnAicT35TWPs5IcwKD8S333HMaa2VVv4+wdvebJkjWuW/xESoB8IwRcog8HYVYamb1g/R31Qv5Bx03g==",
-            "peer": true,
             "requires": {
                 "@types/eslint": "*",
                 "@types/estree": "*"
@@ -14393,8 +14350,7 @@
         "@types/estree": {
             "version": "0.0.51",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
-            "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
-            "peer": true
+            "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ=="
         },
         "@types/express": {
             "version": "4.17.13",
@@ -14611,7 +14567,6 @@
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
             "integrity": "sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==",
-            "peer": true,
             "requires": {
                 "@webassemblyjs/helper-numbers": "1.11.1",
                 "@webassemblyjs/helper-wasm-bytecode": "1.11.1"
@@ -14620,26 +14575,22 @@
         "@webassemblyjs/floating-point-hex-parser": {
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz",
-            "integrity": "sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==",
-            "peer": true
+            "integrity": "sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ=="
         },
         "@webassemblyjs/helper-api-error": {
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz",
-            "integrity": "sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==",
-            "peer": true
+            "integrity": "sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg=="
         },
         "@webassemblyjs/helper-buffer": {
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz",
-            "integrity": "sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==",
-            "peer": true
+            "integrity": "sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA=="
         },
         "@webassemblyjs/helper-numbers": {
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz",
             "integrity": "sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==",
-            "peer": true,
             "requires": {
                 "@webassemblyjs/floating-point-hex-parser": "1.11.1",
                 "@webassemblyjs/helper-api-error": "1.11.1",
@@ -14649,14 +14600,12 @@
         "@webassemblyjs/helper-wasm-bytecode": {
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz",
-            "integrity": "sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==",
-            "peer": true
+            "integrity": "sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q=="
         },
         "@webassemblyjs/helper-wasm-section": {
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz",
             "integrity": "sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==",
-            "peer": true,
             "requires": {
                 "@webassemblyjs/ast": "1.11.1",
                 "@webassemblyjs/helper-buffer": "1.11.1",
@@ -14668,7 +14617,6 @@
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz",
             "integrity": "sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==",
-            "peer": true,
             "requires": {
                 "@xtuc/ieee754": "^1.2.0"
             }
@@ -14677,7 +14625,6 @@
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.1.tgz",
             "integrity": "sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==",
-            "peer": true,
             "requires": {
                 "@xtuc/long": "4.2.2"
             }
@@ -14685,14 +14632,12 @@
         "@webassemblyjs/utf8": {
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.1.tgz",
-            "integrity": "sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==",
-            "peer": true
+            "integrity": "sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ=="
         },
         "@webassemblyjs/wasm-edit": {
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz",
             "integrity": "sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==",
-            "peer": true,
             "requires": {
                 "@webassemblyjs/ast": "1.11.1",
                 "@webassemblyjs/helper-buffer": "1.11.1",
@@ -14708,7 +14653,6 @@
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz",
             "integrity": "sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==",
-            "peer": true,
             "requires": {
                 "@webassemblyjs/ast": "1.11.1",
                 "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
@@ -14721,7 +14665,6 @@
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz",
             "integrity": "sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==",
-            "peer": true,
             "requires": {
                 "@webassemblyjs/ast": "1.11.1",
                 "@webassemblyjs/helper-buffer": "1.11.1",
@@ -14733,7 +14676,6 @@
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz",
             "integrity": "sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==",
-            "peer": true,
             "requires": {
                 "@webassemblyjs/ast": "1.11.1",
                 "@webassemblyjs/helper-api-error": "1.11.1",
@@ -14747,7 +14689,6 @@
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz",
             "integrity": "sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==",
-            "peer": true,
             "requires": {
                 "@webassemblyjs/ast": "1.11.1",
                 "@xtuc/long": "4.2.2"
@@ -14776,14 +14717,12 @@
         "@xtuc/ieee754": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
-            "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
-            "peer": true
+            "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA=="
         },
         "@xtuc/long": {
             "version": "4.2.2",
             "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
-            "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
-            "peer": true
+            "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
         },
         "abbrev": {
             "version": "1.1.1",
@@ -14850,7 +14789,6 @@
             "version": "3.5.2",
             "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
             "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-            "peer": true,
             "requires": {}
         },
         "ansi-align": {
@@ -16967,8 +16905,7 @@
         "es-module-lexer": {
             "version": "0.9.3",
             "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
-            "integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==",
-            "peer": true
+            "integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ=="
         },
         "es-to-primitive": {
             "version": "1.2.1",
@@ -17686,8 +17623,7 @@
         "glob-to-regexp": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-            "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-            "peer": true
+            "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
         },
         "glob2base": {
             "version": "0.0.12",
@@ -18647,7 +18583,6 @@
             "version": "27.4.6",
             "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.4.6.tgz",
             "integrity": "sha512-gHWJF/6Xi5CTG5QCvROr6GcmpIqNYpDJyc8A1h/DyXqH1tD6SnRCM0d3U5msV31D2LB/U+E0M+W4oyvKV44oNw==",
-            "peer": true,
             "requires": {
                 "@types/node": "*",
                 "merge-stream": "^2.0.0",
@@ -18658,7 +18593,6 @@
                     "version": "8.1.1",
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
                     "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-                    "peer": true,
                     "requires": {
                         "has-flag": "^4.0.0"
                     }
@@ -18831,8 +18765,7 @@
         "loader-runner": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.2.0.tgz",
-            "integrity": "sha512-92+huvxMvYlMzMt0iIOukcwYBFpkYJdpl2xsZ7LrlayO7E8SOv+JJUEK17B/dJIHAOLMfh2dZZ/Y18WgmGtYNw==",
-            "peer": true
+            "integrity": "sha512-92+huvxMvYlMzMt0iIOukcwYBFpkYJdpl2xsZ7LrlayO7E8SOv+JJUEK17B/dJIHAOLMfh2dZZ/Y18WgmGtYNw=="
         },
         "loader-utils": {
             "version": "2.0.0",
@@ -19031,8 +18964,7 @@
         "merge-stream": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-            "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-            "peer": true
+            "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
         },
         "merge2": {
             "version": "1.4.1",
@@ -19314,8 +19246,7 @@
         "neo-async": {
             "version": "2.6.2",
             "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-            "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-            "peer": true
+            "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
         },
         "nice-try": {
             "version": "1.0.5",
@@ -21067,7 +20998,6 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
             "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
-            "peer": true,
             "requires": {
                 "@types/json-schema": "^7.0.8",
                 "ajv": "^6.12.5",
@@ -21936,7 +21866,6 @@
             "version": "5.3.0",
             "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.0.tgz",
             "integrity": "sha512-LPIisi3Ol4chwAaPP8toUJ3L4qCM1G0wao7L3qNv57Drezxj6+VEyySpPw4B1HSO2Eg/hDY/MNF5XihCAoqnsQ==",
-            "peer": true,
             "requires": {
                 "jest-worker": "^27.4.1",
                 "schema-utils": "^3.1.1",
@@ -21955,14 +21884,12 @@
                 "source-map": {
                     "version": "0.6.1",
                     "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-                    "peer": true
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
                 },
                 "terser": {
                     "version": "5.10.0",
                     "resolved": "https://registry.npmjs.org/terser/-/terser-5.10.0.tgz",
                     "integrity": "sha512-AMmF99DMfEDiRJfxfY5jj5wNH/bYO09cniSqhfoyxc8sFoYIgkJy86G04UoZU5VjlpnplVu0K6Tx6E9b5+DlHA==",
-                    "peer": true,
                     "requires": {
                         "commander": "^2.20.0",
                         "source-map": "~0.7.2",
@@ -21972,8 +21899,7 @@
                         "source-map": {
                             "version": "0.7.3",
                             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-                            "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-                            "peer": true
+                            "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
                         }
                     }
                 }
@@ -22462,7 +22388,6 @@
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.3.1.tgz",
             "integrity": "sha512-x0t0JuydIo8qCNctdDrn1OzH/qDzk2+rdCOC3YzumZ42fiMqmQ7T3xQurykYMhYfHaPHTp4ZxAx2NfUo1K6QaA==",
-            "peer": true,
             "requires": {
                 "glob-to-regexp": "^0.4.1",
                 "graceful-fs": "^4.1.2"
@@ -22487,7 +22412,6 @@
             "version": "5.73.0",
             "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.73.0.tgz",
             "integrity": "sha512-svjudQRPPa0YiOYa2lM/Gacw0r6PvxptHj4FuEKQ2kX05ZLkjbVc5MnPs6its5j7IZljnIqSVo/OsY2X0IpHGA==",
-            "peer": true,
             "requires": {
                 "@types/eslint-scope": "^3.7.3",
                 "@types/estree": "^0.0.51",
@@ -22518,21 +22442,18 @@
                 "acorn": {
                     "version": "8.7.0",
                     "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-                    "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
-                    "peer": true
+                    "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ=="
                 },
                 "acorn-import-assertions": {
                     "version": "1.8.0",
                     "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
                     "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
-                    "peer": true,
                     "requires": {}
                 },
                 "enhanced-resolve": {
                     "version": "5.9.3",
                     "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.9.3.tgz",
                     "integrity": "sha512-Bq9VSor+kjvW3f9/MiiR4eE3XYgOl7/rS8lnSxbRbF3kS0B2r+Y9w5krBWxZgDxASVZbdYrn5wT4j/Wb0J9qow==",
-                    "peer": true,
                     "requires": {
                         "graceful-fs": "^4.2.4",
                         "tapable": "^2.2.0"
@@ -22541,14 +22462,12 @@
                 "mime-db": {
                     "version": "1.51.0",
                     "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
-                    "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==",
-                    "peer": true
+                    "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g=="
                 },
                 "mime-types": {
                     "version": "2.1.34",
                     "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
                     "integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
-                    "peer": true,
                     "requires": {
                         "mime-db": "1.51.0"
                     }
@@ -22556,8 +22475,7 @@
                 "tapable": {
                     "version": "2.2.1",
                     "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
-                    "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
-                    "peer": true
+                    "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ=="
                 }
             }
         },
@@ -22604,8 +22522,7 @@
         "webpack-sources": {
             "version": "3.2.3",
             "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
-            "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
-            "peer": true
+            "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w=="
         },
         "whatwg-encoding": {
             "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,7 @@
             "license": "MIT",
             "dependencies": {
                 "vscode-uri": "^3.0.3",
-                "webpack": "^5.67.0",
-                "webpack-cli": "^4.9.2"
+                "webpack-cli": "^4.10.0"
             },
             "devDependencies": {
                 "@types/glob": "^7.1.3",
@@ -2149,6 +2148,7 @@
             "version": "8.4.1",
             "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.1.tgz",
             "integrity": "sha512-GE44+DNEyxxh2Kc6ro/VkIj+9ma0pO0bwv9+uHSyBrikYOHr8zYcdPvnBOp1aw8s+CjRvuSx7CyWqRrNFQ59mA==",
+            "peer": true,
             "dependencies": {
                 "@types/estree": "*",
                 "@types/json-schema": "*"
@@ -2158,15 +2158,17 @@
             "version": "3.7.3",
             "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.3.tgz",
             "integrity": "sha512-PB3ldyrcnAicT35TWPs5IcwKD8S333HMaa2VVv4+wdvebJkjWuW/xESoB8IwRcog8HYVYamb1g/R31Qv5Bx03g==",
+            "peer": true,
             "dependencies": {
                 "@types/eslint": "*",
                 "@types/estree": "*"
             }
         },
         "node_modules/@types/estree": {
-            "version": "0.0.50",
-            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz",
-            "integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw=="
+            "version": "0.0.51",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
+            "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
+            "peer": true
         },
         "node_modules/@types/express": {
             "version": "4.17.13",
@@ -2404,6 +2406,7 @@
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
             "integrity": "sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==",
+            "peer": true,
             "dependencies": {
                 "@webassemblyjs/helper-numbers": "1.11.1",
                 "@webassemblyjs/helper-wasm-bytecode": "1.11.1"
@@ -2412,22 +2415,26 @@
         "node_modules/@webassemblyjs/floating-point-hex-parser": {
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz",
-            "integrity": "sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ=="
+            "integrity": "sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==",
+            "peer": true
         },
         "node_modules/@webassemblyjs/helper-api-error": {
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz",
-            "integrity": "sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg=="
+            "integrity": "sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==",
+            "peer": true
         },
         "node_modules/@webassemblyjs/helper-buffer": {
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz",
-            "integrity": "sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA=="
+            "integrity": "sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==",
+            "peer": true
         },
         "node_modules/@webassemblyjs/helper-numbers": {
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz",
             "integrity": "sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==",
+            "peer": true,
             "dependencies": {
                 "@webassemblyjs/floating-point-hex-parser": "1.11.1",
                 "@webassemblyjs/helper-api-error": "1.11.1",
@@ -2437,12 +2444,14 @@
         "node_modules/@webassemblyjs/helper-wasm-bytecode": {
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz",
-            "integrity": "sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q=="
+            "integrity": "sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==",
+            "peer": true
         },
         "node_modules/@webassemblyjs/helper-wasm-section": {
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz",
             "integrity": "sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==",
+            "peer": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.11.1",
                 "@webassemblyjs/helper-buffer": "1.11.1",
@@ -2454,6 +2463,7 @@
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz",
             "integrity": "sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==",
+            "peer": true,
             "dependencies": {
                 "@xtuc/ieee754": "^1.2.0"
             }
@@ -2462,6 +2472,7 @@
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.1.tgz",
             "integrity": "sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==",
+            "peer": true,
             "dependencies": {
                 "@xtuc/long": "4.2.2"
             }
@@ -2469,12 +2480,14 @@
         "node_modules/@webassemblyjs/utf8": {
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.1.tgz",
-            "integrity": "sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ=="
+            "integrity": "sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==",
+            "peer": true
         },
         "node_modules/@webassemblyjs/wasm-edit": {
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz",
             "integrity": "sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==",
+            "peer": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.11.1",
                 "@webassemblyjs/helper-buffer": "1.11.1",
@@ -2490,6 +2503,7 @@
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz",
             "integrity": "sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==",
+            "peer": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.11.1",
                 "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
@@ -2502,6 +2516,7 @@
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz",
             "integrity": "sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==",
+            "peer": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.11.1",
                 "@webassemblyjs/helper-buffer": "1.11.1",
@@ -2513,6 +2528,7 @@
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz",
             "integrity": "sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==",
+            "peer": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.11.1",
                 "@webassemblyjs/helper-api-error": "1.11.1",
@@ -2526,24 +2542,25 @@
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz",
             "integrity": "sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==",
+            "peer": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.11.1",
                 "@xtuc/long": "4.2.2"
             }
         },
         "node_modules/@webpack-cli/configtest": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.1.1.tgz",
-            "integrity": "sha512-1FBc1f9G4P/AxMqIgfZgeOTuRnwZMten8E7zap5zgpPInnCrP8D4Q81+4CWIch8i/Nf7nXjP0v6CjjbHOrXhKg==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.2.0.tgz",
+            "integrity": "sha512-4FB8Tj6xyVkyqjj1OaTqCjXYULB9FMkqQ8yGrZjRDrYh0nOE+7Lhs45WioWQQMV+ceFlE368Ukhe6xdvJM9Egg==",
             "peerDependencies": {
                 "webpack": "4.x.x || 5.x.x",
                 "webpack-cli": "4.x.x"
             }
         },
         "node_modules/@webpack-cli/info": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.4.1.tgz",
-            "integrity": "sha512-PKVGmazEq3oAo46Q63tpMr4HipI3OPfP7LiNOEJg963RMgT0rqheag28NCML0o3GIzA3DmxP1ZIAv9oTX1CUIA==",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.5.0.tgz",
+            "integrity": "sha512-e8tSXZpw2hPl2uMJY6fsMswaok5FdlGNRTktvFk2sD8RjH0hE2+XistawJx1vmKteh4NmGmNUrp+Tb2w+udPcQ==",
             "dependencies": {
                 "envinfo": "^7.7.3"
             },
@@ -2552,9 +2569,9 @@
             }
         },
         "node_modules/@webpack-cli/serve": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.6.1.tgz",
-            "integrity": "sha512-gNGTiTrjEVQ0OcVnzsRSqTxaBSr+dmTfm+qJsCDluky8uhdLWep7Gcr62QsAKHTMxjCS/8nEITsmFAhfIx+QSw==",
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.7.0.tgz",
+            "integrity": "sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==",
             "peerDependencies": {
                 "webpack-cli": "4.x.x"
             },
@@ -2567,12 +2584,14 @@
         "node_modules/@xtuc/ieee754": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
-            "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA=="
+            "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
+            "peer": true
         },
         "node_modules/@xtuc/long": {
             "version": "4.2.2",
             "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
-            "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
+            "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
+            "peer": true
         },
         "node_modules/abbrev": {
             "version": "1.1.1",
@@ -2651,6 +2670,7 @@
             "version": "3.5.2",
             "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
             "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+            "peer": true,
             "peerDependencies": {
                 "ajv": "^6.9.1"
             }
@@ -5298,7 +5318,8 @@
         "node_modules/es-module-lexer": {
             "version": "0.9.3",
             "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
-            "integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ=="
+            "integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==",
+            "peer": true
         },
         "node_modules/es-to-primitive": {
             "version": "1.2.1",
@@ -5563,28 +5584,6 @@
             "dependencies": {
                 "md5.js": "^1.3.4",
                 "safe-buffer": "^5.1.1"
-            }
-        },
-        "node_modules/execa": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
-            "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
-            "dependencies": {
-                "cross-spawn": "^7.0.3",
-                "get-stream": "^6.0.0",
-                "human-signals": "^2.1.0",
-                "is-stream": "^2.0.0",
-                "merge-stream": "^2.0.0",
-                "npm-run-path": "^4.0.1",
-                "onetime": "^5.1.2",
-                "signal-exit": "^3.0.3",
-                "strip-final-newline": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/execa?sponsor=1"
             }
         },
         "node_modules/expand-brackets": {
@@ -6126,17 +6125,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/get-stream": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-            "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/get-symbol-description": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
@@ -6240,7 +6228,8 @@
         "node_modules/glob-to-regexp": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-            "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
+            "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+            "peer": true
         },
         "node_modules/glob2base": {
             "version": "0.0.12",
@@ -6704,14 +6693,6 @@
             },
             "engines": {
                 "node": ">= 6"
-            }
-        },
-        "node_modules/human-signals": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
-            "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
-            "engines": {
-                "node": ">=10.17.0"
             }
         },
         "node_modules/iconv-lite": {
@@ -7320,17 +7301,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/is-stream": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-            "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/is-string": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
@@ -7577,6 +7547,7 @@
             "version": "27.4.6",
             "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.4.6.tgz",
             "integrity": "sha512-gHWJF/6Xi5CTG5QCvROr6GcmpIqNYpDJyc8A1h/DyXqH1tD6SnRCM0d3U5msV31D2LB/U+E0M+W4oyvKV44oNw==",
+            "peer": true,
             "dependencies": {
                 "@types/node": "*",
                 "merge-stream": "^2.0.0",
@@ -7590,6 +7561,7 @@
             "version": "8.1.1",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
             "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+            "peer": true,
             "dependencies": {
                 "has-flag": "^4.0.0"
             },
@@ -7640,13 +7612,13 @@
         "node_modules/json-parse-better-errors": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-            "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
+            "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+            "dev": true
         },
         "node_modules/json-parse-even-better-errors": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-            "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-            "dev": true
+            "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
         },
         "node_modules/json-schema-traverse": {
             "version": "0.4.1",
@@ -7801,6 +7773,7 @@
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.2.0.tgz",
             "integrity": "sha512-92+huvxMvYlMzMt0iIOukcwYBFpkYJdpl2xsZ7LrlayO7E8SOv+JJUEK17B/dJIHAOLMfh2dZZ/Y18WgmGtYNw==",
+            "peer": true,
             "engines": {
                 "node": ">=6.11.5"
             }
@@ -8044,7 +8017,8 @@
         "node_modules/merge-stream": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-            "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
+            "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+            "peer": true
         },
         "node_modules/merge2": {
             "version": "1.4.1",
@@ -8124,6 +8098,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
             "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+            "dev": true,
             "engines": {
                 "node": ">=6"
             }
@@ -8398,7 +8373,8 @@
         "node_modules/neo-async": {
             "version": "2.6.2",
             "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-            "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
+            "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+            "peer": true
         },
         "node_modules/nice-try": {
             "version": "1.0.5",
@@ -8744,17 +8720,6 @@
                 "which": "bin/which"
             }
         },
-        "node_modules/npm-run-path": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-            "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-            "dependencies": {
-                "path-key": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/npm-watch": {
             "version": "0.10.0",
             "resolved": "https://registry.npmjs.org/npm-watch/-/npm-watch-0.10.0.tgz",
@@ -9017,6 +8982,7 @@
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
             "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+            "dev": true,
             "dependencies": {
                 "mimic-fn": "^2.1.0"
             },
@@ -10771,6 +10737,7 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
             "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+            "peer": true,
             "dependencies": {
                 "@types/json-schema": "^7.0.8",
                 "ajv": "^6.12.5",
@@ -10958,7 +10925,8 @@
         "node_modules/signal-exit": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-            "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
+            "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+            "dev": true
         },
         "node_modules/simple-swizzle": {
             "version": "0.2.2",
@@ -11576,14 +11544,6 @@
                 "node": ">=4"
             }
         },
-        "node_modules/strip-final-newline": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-            "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/strip-json-comments": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -11825,6 +11785,7 @@
             "version": "5.3.0",
             "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.0.tgz",
             "integrity": "sha512-LPIisi3Ol4chwAaPP8toUJ3L4qCM1G0wao7L3qNv57Drezxj6+VEyySpPw4B1HSO2Eg/hDY/MNF5XihCAoqnsQ==",
+            "peer": true,
             "dependencies": {
                 "jest-worker": "^27.4.1",
                 "schema-utils": "^3.1.1",
@@ -11871,6 +11832,7 @@
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
             "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -11879,6 +11841,7 @@
             "version": "5.10.0",
             "resolved": "https://registry.npmjs.org/terser/-/terser-5.10.0.tgz",
             "integrity": "sha512-AMmF99DMfEDiRJfxfY5jj5wNH/bYO09cniSqhfoyxc8sFoYIgkJy86G04UoZU5VjlpnplVu0K6Tx6E9b5+DlHA==",
+            "peer": true,
             "dependencies": {
                 "commander": "^2.20.0",
                 "source-map": "~0.7.2",
@@ -11903,6 +11866,7 @@
             "version": "0.7.3",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
             "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+            "peer": true,
             "engines": {
                 "node": ">= 8"
             }
@@ -12480,6 +12444,7 @@
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.3.1.tgz",
             "integrity": "sha512-x0t0JuydIo8qCNctdDrn1OzH/qDzk2+rdCOC3YzumZ42fiMqmQ7T3xQurykYMhYfHaPHTp4ZxAx2NfUo1K6QaA==",
+            "peer": true,
             "dependencies": {
                 "glob-to-regexp": "^0.4.1",
                 "graceful-fs": "^4.1.2"
@@ -12504,12 +12469,13 @@
             "dev": true
         },
         "node_modules/webpack": {
-            "version": "5.67.0",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.67.0.tgz",
-            "integrity": "sha512-LjFbfMh89xBDpUMgA1W9Ur6Rn/gnr2Cq1jjHFPo4v6a79/ypznSYbAyPgGhwsxBtMIaEmDD1oJoA7BEYw/Fbrw==",
+            "version": "5.73.0",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.73.0.tgz",
+            "integrity": "sha512-svjudQRPPa0YiOYa2lM/Gacw0r6PvxptHj4FuEKQ2kX05ZLkjbVc5MnPs6its5j7IZljnIqSVo/OsY2X0IpHGA==",
+            "peer": true,
             "dependencies": {
-                "@types/eslint-scope": "^3.7.0",
-                "@types/estree": "^0.0.50",
+                "@types/eslint-scope": "^3.7.3",
+                "@types/estree": "^0.0.51",
                 "@webassemblyjs/ast": "1.11.1",
                 "@webassemblyjs/wasm-edit": "1.11.1",
                 "@webassemblyjs/wasm-parser": "1.11.1",
@@ -12517,13 +12483,13 @@
                 "acorn-import-assertions": "^1.7.6",
                 "browserslist": "^4.14.5",
                 "chrome-trace-event": "^1.0.2",
-                "enhanced-resolve": "^5.8.3",
+                "enhanced-resolve": "^5.9.3",
                 "es-module-lexer": "^0.9.0",
                 "eslint-scope": "5.1.1",
                 "events": "^3.2.0",
                 "glob-to-regexp": "^0.4.1",
                 "graceful-fs": "^4.2.9",
-                "json-parse-better-errors": "^1.0.2",
+                "json-parse-even-better-errors": "^2.3.1",
                 "loader-runner": "^4.2.0",
                 "mime-types": "^2.1.27",
                 "neo-async": "^2.6.2",
@@ -12550,17 +12516,17 @@
             }
         },
         "node_modules/webpack-cli": {
-            "version": "4.9.2",
-            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.9.2.tgz",
-            "integrity": "sha512-m3/AACnBBzK/kMTcxWHcZFPrw/eQuY4Df1TxvIWfWM2x7mRqBQCqKEd96oCUa9jkapLBaFfRce33eGDb4Pr7YQ==",
+            "version": "4.10.0",
+            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.10.0.tgz",
+            "integrity": "sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==",
             "dependencies": {
                 "@discoveryjs/json-ext": "^0.5.0",
-                "@webpack-cli/configtest": "^1.1.1",
-                "@webpack-cli/info": "^1.4.1",
-                "@webpack-cli/serve": "^1.6.1",
+                "@webpack-cli/configtest": "^1.2.0",
+                "@webpack-cli/info": "^1.5.0",
+                "@webpack-cli/serve": "^1.7.0",
                 "colorette": "^2.0.14",
                 "commander": "^7.0.0",
-                "execa": "^5.0.0",
+                "cross-spawn": "^7.0.3",
                 "fastest-levenshtein": "^1.0.12",
                 "import-local": "^3.0.2",
                 "interpret": "^2.2.0",
@@ -12572,6 +12538,10 @@
             },
             "engines": {
                 "node": ">=10.13.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
             },
             "peerDependencies": {
                 "webpack": "4.x.x || 5.x.x"
@@ -12620,6 +12590,7 @@
             "version": "3.2.3",
             "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
             "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
+            "peer": true,
             "engines": {
                 "node": ">=10.13.0"
             }
@@ -12628,6 +12599,7 @@
             "version": "8.7.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
             "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -12639,14 +12611,16 @@
             "version": "1.8.0",
             "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
             "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
+            "peer": true,
             "peerDependencies": {
                 "acorn": "^8"
             }
         },
         "node_modules/webpack/node_modules/enhanced-resolve": {
-            "version": "5.8.3",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.8.3.tgz",
-            "integrity": "sha512-EGAbGvH7j7Xt2nc0E7D99La1OiEs8LnyimkRgwExpUMScN6O+3x9tIWs7PLQZVNx4YD+00skHXPXi1yQHpAmZA==",
+            "version": "5.9.3",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.9.3.tgz",
+            "integrity": "sha512-Bq9VSor+kjvW3f9/MiiR4eE3XYgOl7/rS8lnSxbRbF3kS0B2r+Y9w5krBWxZgDxASVZbdYrn5wT4j/Wb0J9qow==",
+            "peer": true,
             "dependencies": {
                 "graceful-fs": "^4.2.4",
                 "tapable": "^2.2.0"
@@ -12659,6 +12633,7 @@
             "version": "1.51.0",
             "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
             "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==",
+            "peer": true,
             "engines": {
                 "node": ">= 0.6"
             }
@@ -12667,6 +12642,7 @@
             "version": "2.1.34",
             "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
             "integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
+            "peer": true,
             "dependencies": {
                 "mime-db": "1.51.0"
             },
@@ -12678,6 +12654,7 @@
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
             "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -14397,6 +14374,7 @@
             "version": "8.4.1",
             "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.1.tgz",
             "integrity": "sha512-GE44+DNEyxxh2Kc6ro/VkIj+9ma0pO0bwv9+uHSyBrikYOHr8zYcdPvnBOp1aw8s+CjRvuSx7CyWqRrNFQ59mA==",
+            "peer": true,
             "requires": {
                 "@types/estree": "*",
                 "@types/json-schema": "*"
@@ -14406,15 +14384,17 @@
             "version": "3.7.3",
             "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.3.tgz",
             "integrity": "sha512-PB3ldyrcnAicT35TWPs5IcwKD8S333HMaa2VVv4+wdvebJkjWuW/xESoB8IwRcog8HYVYamb1g/R31Qv5Bx03g==",
+            "peer": true,
             "requires": {
                 "@types/eslint": "*",
                 "@types/estree": "*"
             }
         },
         "@types/estree": {
-            "version": "0.0.50",
-            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz",
-            "integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw=="
+            "version": "0.0.51",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
+            "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
+            "peer": true
         },
         "@types/express": {
             "version": "4.17.13",
@@ -14631,6 +14611,7 @@
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
             "integrity": "sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==",
+            "peer": true,
             "requires": {
                 "@webassemblyjs/helper-numbers": "1.11.1",
                 "@webassemblyjs/helper-wasm-bytecode": "1.11.1"
@@ -14639,22 +14620,26 @@
         "@webassemblyjs/floating-point-hex-parser": {
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz",
-            "integrity": "sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ=="
+            "integrity": "sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==",
+            "peer": true
         },
         "@webassemblyjs/helper-api-error": {
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz",
-            "integrity": "sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg=="
+            "integrity": "sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==",
+            "peer": true
         },
         "@webassemblyjs/helper-buffer": {
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz",
-            "integrity": "sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA=="
+            "integrity": "sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==",
+            "peer": true
         },
         "@webassemblyjs/helper-numbers": {
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz",
             "integrity": "sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==",
+            "peer": true,
             "requires": {
                 "@webassemblyjs/floating-point-hex-parser": "1.11.1",
                 "@webassemblyjs/helper-api-error": "1.11.1",
@@ -14664,12 +14649,14 @@
         "@webassemblyjs/helper-wasm-bytecode": {
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz",
-            "integrity": "sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q=="
+            "integrity": "sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==",
+            "peer": true
         },
         "@webassemblyjs/helper-wasm-section": {
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz",
             "integrity": "sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==",
+            "peer": true,
             "requires": {
                 "@webassemblyjs/ast": "1.11.1",
                 "@webassemblyjs/helper-buffer": "1.11.1",
@@ -14681,6 +14668,7 @@
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz",
             "integrity": "sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==",
+            "peer": true,
             "requires": {
                 "@xtuc/ieee754": "^1.2.0"
             }
@@ -14689,6 +14677,7 @@
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.1.tgz",
             "integrity": "sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==",
+            "peer": true,
             "requires": {
                 "@xtuc/long": "4.2.2"
             }
@@ -14696,12 +14685,14 @@
         "@webassemblyjs/utf8": {
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.1.tgz",
-            "integrity": "sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ=="
+            "integrity": "sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==",
+            "peer": true
         },
         "@webassemblyjs/wasm-edit": {
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz",
             "integrity": "sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==",
+            "peer": true,
             "requires": {
                 "@webassemblyjs/ast": "1.11.1",
                 "@webassemblyjs/helper-buffer": "1.11.1",
@@ -14717,6 +14708,7 @@
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz",
             "integrity": "sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==",
+            "peer": true,
             "requires": {
                 "@webassemblyjs/ast": "1.11.1",
                 "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
@@ -14729,6 +14721,7 @@
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz",
             "integrity": "sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==",
+            "peer": true,
             "requires": {
                 "@webassemblyjs/ast": "1.11.1",
                 "@webassemblyjs/helper-buffer": "1.11.1",
@@ -14740,6 +14733,7 @@
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz",
             "integrity": "sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==",
+            "peer": true,
             "requires": {
                 "@webassemblyjs/ast": "1.11.1",
                 "@webassemblyjs/helper-api-error": "1.11.1",
@@ -14753,40 +14747,43 @@
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz",
             "integrity": "sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==",
+            "peer": true,
             "requires": {
                 "@webassemblyjs/ast": "1.11.1",
                 "@xtuc/long": "4.2.2"
             }
         },
         "@webpack-cli/configtest": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.1.1.tgz",
-            "integrity": "sha512-1FBc1f9G4P/AxMqIgfZgeOTuRnwZMten8E7zap5zgpPInnCrP8D4Q81+4CWIch8i/Nf7nXjP0v6CjjbHOrXhKg==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.2.0.tgz",
+            "integrity": "sha512-4FB8Tj6xyVkyqjj1OaTqCjXYULB9FMkqQ8yGrZjRDrYh0nOE+7Lhs45WioWQQMV+ceFlE368Ukhe6xdvJM9Egg==",
             "requires": {}
         },
         "@webpack-cli/info": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.4.1.tgz",
-            "integrity": "sha512-PKVGmazEq3oAo46Q63tpMr4HipI3OPfP7LiNOEJg963RMgT0rqheag28NCML0o3GIzA3DmxP1ZIAv9oTX1CUIA==",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.5.0.tgz",
+            "integrity": "sha512-e8tSXZpw2hPl2uMJY6fsMswaok5FdlGNRTktvFk2sD8RjH0hE2+XistawJx1vmKteh4NmGmNUrp+Tb2w+udPcQ==",
             "requires": {
                 "envinfo": "^7.7.3"
             }
         },
         "@webpack-cli/serve": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.6.1.tgz",
-            "integrity": "sha512-gNGTiTrjEVQ0OcVnzsRSqTxaBSr+dmTfm+qJsCDluky8uhdLWep7Gcr62QsAKHTMxjCS/8nEITsmFAhfIx+QSw==",
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.7.0.tgz",
+            "integrity": "sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==",
             "requires": {}
         },
         "@xtuc/ieee754": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
-            "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA=="
+            "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
+            "peer": true
         },
         "@xtuc/long": {
             "version": "4.2.2",
             "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
-            "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
+            "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
+            "peer": true
         },
         "abbrev": {
             "version": "1.1.1",
@@ -14853,6 +14850,7 @@
             "version": "3.5.2",
             "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
             "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+            "peer": true,
             "requires": {}
         },
         "ansi-align": {
@@ -16969,7 +16967,8 @@
         "es-module-lexer": {
             "version": "0.9.3",
             "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
-            "integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ=="
+            "integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==",
+            "peer": true
         },
         "es-to-primitive": {
             "version": "1.2.1",
@@ -17175,22 +17174,6 @@
             "requires": {
                 "md5.js": "^1.3.4",
                 "safe-buffer": "^5.1.1"
-            }
-        },
-        "execa": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
-            "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
-            "requires": {
-                "cross-spawn": "^7.0.3",
-                "get-stream": "^6.0.0",
-                "human-signals": "^2.1.0",
-                "is-stream": "^2.0.0",
-                "merge-stream": "^2.0.0",
-                "npm-run-path": "^4.0.1",
-                "onetime": "^5.1.2",
-                "signal-exit": "^3.0.3",
-                "strip-final-newline": "^2.0.0"
             }
         },
         "expand-brackets": {
@@ -17625,11 +17608,6 @@
             "integrity": "sha512-/b3jarXkH8KJoOMQc3uVGHASwGLPq3gSFJ7tgJm2diza+bydJPTGOibin2steecKeOylE8oY2JERlVWkAJO6yw==",
             "dev": true
         },
-        "get-stream": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-            "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="
-        },
         "get-symbol-description": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
@@ -17708,7 +17686,8 @@
         "glob-to-regexp": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-            "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
+            "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+            "peer": true
         },
         "glob2base": {
             "version": "0.0.12",
@@ -18067,11 +18046,6 @@
                 "agent-base": "6",
                 "debug": "4"
             }
-        },
-        "human-signals": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
-            "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="
         },
         "iconv-lite": {
             "version": "0.6.3",
@@ -18485,11 +18459,6 @@
             "integrity": "sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==",
             "dev": true
         },
-        "is-stream": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-            "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="
-        },
         "is-string": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
@@ -18678,6 +18647,7 @@
             "version": "27.4.6",
             "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.4.6.tgz",
             "integrity": "sha512-gHWJF/6Xi5CTG5QCvROr6GcmpIqNYpDJyc8A1h/DyXqH1tD6SnRCM0d3U5msV31D2LB/U+E0M+W4oyvKV44oNw==",
+            "peer": true,
             "requires": {
                 "@types/node": "*",
                 "merge-stream": "^2.0.0",
@@ -18688,6 +18658,7 @@
                     "version": "8.1.1",
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
                     "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+                    "peer": true,
                     "requires": {
                         "has-flag": "^4.0.0"
                     }
@@ -18725,13 +18696,13 @@
         "json-parse-better-errors": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-            "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
+            "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+            "dev": true
         },
         "json-parse-even-better-errors": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-            "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-            "dev": true
+            "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
         },
         "json-schema-traverse": {
             "version": "0.4.1",
@@ -18860,7 +18831,8 @@
         "loader-runner": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.2.0.tgz",
-            "integrity": "sha512-92+huvxMvYlMzMt0iIOukcwYBFpkYJdpl2xsZ7LrlayO7E8SOv+JJUEK17B/dJIHAOLMfh2dZZ/Y18WgmGtYNw=="
+            "integrity": "sha512-92+huvxMvYlMzMt0iIOukcwYBFpkYJdpl2xsZ7LrlayO7E8SOv+JJUEK17B/dJIHAOLMfh2dZZ/Y18WgmGtYNw==",
+            "peer": true
         },
         "loader-utils": {
             "version": "2.0.0",
@@ -19059,7 +19031,8 @@
         "merge-stream": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-            "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
+            "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+            "peer": true
         },
         "merge2": {
             "version": "1.4.1",
@@ -19119,7 +19092,8 @@
         "mimic-fn": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
+            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+            "dev": true
         },
         "mimic-response": {
             "version": "1.0.1",
@@ -19340,7 +19314,8 @@
         "neo-async": {
             "version": "2.6.2",
             "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-            "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
+            "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+            "peer": true
         },
         "nice-try": {
             "version": "1.0.5",
@@ -19602,14 +19577,6 @@
                 }
             }
         },
-        "npm-run-path": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-            "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-            "requires": {
-                "path-key": "^3.0.0"
-            }
-        },
         "npm-watch": {
             "version": "0.10.0",
             "resolved": "https://registry.npmjs.org/npm-watch/-/npm-watch-0.10.0.tgz",
@@ -19815,6 +19782,7 @@
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
             "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+            "dev": true,
             "requires": {
                 "mimic-fn": "^2.1.0"
             }
@@ -21099,6 +21067,7 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
             "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+            "peer": true,
             "requires": {
                 "@types/json-schema": "^7.0.8",
                 "ajv": "^6.12.5",
@@ -21249,7 +21218,8 @@
         "signal-exit": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-            "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
+            "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+            "dev": true
         },
         "simple-swizzle": {
             "version": "0.2.2",
@@ -21778,11 +21748,6 @@
             "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
             "dev": true
         },
-        "strip-final-newline": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-            "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="
-        },
         "strip-json-comments": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -21971,6 +21936,7 @@
             "version": "5.3.0",
             "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.0.tgz",
             "integrity": "sha512-LPIisi3Ol4chwAaPP8toUJ3L4qCM1G0wao7L3qNv57Drezxj6+VEyySpPw4B1HSO2Eg/hDY/MNF5XihCAoqnsQ==",
+            "peer": true,
             "requires": {
                 "jest-worker": "^27.4.1",
                 "schema-utils": "^3.1.1",
@@ -21989,12 +21955,14 @@
                 "source-map": {
                     "version": "0.6.1",
                     "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "peer": true
                 },
                 "terser": {
                     "version": "5.10.0",
                     "resolved": "https://registry.npmjs.org/terser/-/terser-5.10.0.tgz",
                     "integrity": "sha512-AMmF99DMfEDiRJfxfY5jj5wNH/bYO09cniSqhfoyxc8sFoYIgkJy86G04UoZU5VjlpnplVu0K6Tx6E9b5+DlHA==",
+                    "peer": true,
                     "requires": {
                         "commander": "^2.20.0",
                         "source-map": "~0.7.2",
@@ -22004,7 +21972,8 @@
                         "source-map": {
                             "version": "0.7.3",
                             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-                            "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
+                            "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+                            "peer": true
                         }
                     }
                 }
@@ -22493,6 +22462,7 @@
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.3.1.tgz",
             "integrity": "sha512-x0t0JuydIo8qCNctdDrn1OzH/qDzk2+rdCOC3YzumZ42fiMqmQ7T3xQurykYMhYfHaPHTp4ZxAx2NfUo1K6QaA==",
+            "peer": true,
             "requires": {
                 "glob-to-regexp": "^0.4.1",
                 "graceful-fs": "^4.1.2"
@@ -22514,12 +22484,13 @@
             "dev": true
         },
         "webpack": {
-            "version": "5.67.0",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.67.0.tgz",
-            "integrity": "sha512-LjFbfMh89xBDpUMgA1W9Ur6Rn/gnr2Cq1jjHFPo4v6a79/ypznSYbAyPgGhwsxBtMIaEmDD1oJoA7BEYw/Fbrw==",
+            "version": "5.73.0",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.73.0.tgz",
+            "integrity": "sha512-svjudQRPPa0YiOYa2lM/Gacw0r6PvxptHj4FuEKQ2kX05ZLkjbVc5MnPs6its5j7IZljnIqSVo/OsY2X0IpHGA==",
+            "peer": true,
             "requires": {
-                "@types/eslint-scope": "^3.7.0",
-                "@types/estree": "^0.0.50",
+                "@types/eslint-scope": "^3.7.3",
+                "@types/estree": "^0.0.51",
                 "@webassemblyjs/ast": "1.11.1",
                 "@webassemblyjs/wasm-edit": "1.11.1",
                 "@webassemblyjs/wasm-parser": "1.11.1",
@@ -22527,13 +22498,13 @@
                 "acorn-import-assertions": "^1.7.6",
                 "browserslist": "^4.14.5",
                 "chrome-trace-event": "^1.0.2",
-                "enhanced-resolve": "^5.8.3",
+                "enhanced-resolve": "^5.9.3",
                 "es-module-lexer": "^0.9.0",
                 "eslint-scope": "5.1.1",
                 "events": "^3.2.0",
                 "glob-to-regexp": "^0.4.1",
                 "graceful-fs": "^4.2.9",
-                "json-parse-better-errors": "^1.0.2",
+                "json-parse-even-better-errors": "^2.3.1",
                 "loader-runner": "^4.2.0",
                 "mime-types": "^2.1.27",
                 "neo-async": "^2.6.2",
@@ -22547,18 +22518,21 @@
                 "acorn": {
                     "version": "8.7.0",
                     "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-                    "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ=="
+                    "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+                    "peer": true
                 },
                 "acorn-import-assertions": {
                     "version": "1.8.0",
                     "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
                     "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
+                    "peer": true,
                     "requires": {}
                 },
                 "enhanced-resolve": {
-                    "version": "5.8.3",
-                    "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.8.3.tgz",
-                    "integrity": "sha512-EGAbGvH7j7Xt2nc0E7D99La1OiEs8LnyimkRgwExpUMScN6O+3x9tIWs7PLQZVNx4YD+00skHXPXi1yQHpAmZA==",
+                    "version": "5.9.3",
+                    "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.9.3.tgz",
+                    "integrity": "sha512-Bq9VSor+kjvW3f9/MiiR4eE3XYgOl7/rS8lnSxbRbF3kS0B2r+Y9w5krBWxZgDxASVZbdYrn5wT4j/Wb0J9qow==",
+                    "peer": true,
                     "requires": {
                         "graceful-fs": "^4.2.4",
                         "tapable": "^2.2.0"
@@ -22567,12 +22541,14 @@
                 "mime-db": {
                     "version": "1.51.0",
                     "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
-                    "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g=="
+                    "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==",
+                    "peer": true
                 },
                 "mime-types": {
                     "version": "2.1.34",
                     "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
                     "integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
+                    "peer": true,
                     "requires": {
                         "mime-db": "1.51.0"
                     }
@@ -22580,22 +22556,23 @@
                 "tapable": {
                     "version": "2.2.1",
                     "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
-                    "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ=="
+                    "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+                    "peer": true
                 }
             }
         },
         "webpack-cli": {
-            "version": "4.9.2",
-            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.9.2.tgz",
-            "integrity": "sha512-m3/AACnBBzK/kMTcxWHcZFPrw/eQuY4Df1TxvIWfWM2x7mRqBQCqKEd96oCUa9jkapLBaFfRce33eGDb4Pr7YQ==",
+            "version": "4.10.0",
+            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.10.0.tgz",
+            "integrity": "sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==",
             "requires": {
                 "@discoveryjs/json-ext": "^0.5.0",
-                "@webpack-cli/configtest": "^1.1.1",
-                "@webpack-cli/info": "^1.4.1",
-                "@webpack-cli/serve": "^1.6.1",
+                "@webpack-cli/configtest": "^1.2.0",
+                "@webpack-cli/info": "^1.5.0",
+                "@webpack-cli/serve": "^1.7.0",
                 "colorette": "^2.0.14",
                 "commander": "^7.0.0",
-                "execa": "^5.0.0",
+                "cross-spawn": "^7.0.3",
                 "fastest-levenshtein": "^1.0.12",
                 "import-local": "^3.0.2",
                 "interpret": "^2.2.0",
@@ -22627,7 +22604,8 @@
         "webpack-sources": {
             "version": "3.2.3",
             "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
-            "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w=="
+            "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
+            "peer": true
         },
         "whatwg-encoding": {
             "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -475,7 +475,7 @@
     },
     "dependencies": {
         "vscode-uri": "^3.0.3",
-        "webpack": "^5.67.0",
+        "webpack": "^5.73.0",
         "webpack-cli": "^4.9.2"
     }
 }

--- a/package.json
+++ b/package.json
@@ -388,6 +388,14 @@
                 "command": "modalkeys.toggleKeymap"
             },
             {
+                "key": "alt+;",
+                "command": "modelkeys.nextKeytip"
+            },
+            {
+                "key": "shift+alt+;",
+                "command": "modalkeys.previousKeytip"
+            },
+            {
                 "key": "Escape",
                 "command": "modalkeys.enterNormal",
                 "when": "editorTextFocus && !suggestWidgetMultipleSuggestions && !suggestWidgetVisible"

--- a/package.json
+++ b/package.json
@@ -440,7 +440,7 @@
         "build-docs": "npm-run-all --serial build-html-docs parcel-build-docs",
         "build-dev-docs": "npm-run-all --serial build-html-docs parcel-build-dev-docs",
         "predebug": "rm -rf dist",
-        "debug": "npx tsc --outDir dist",
+        "debug": "npx webpack --mode development",
         "prepackage": "rm -rf dist",
         "lint": "eslint src --ext ts"
     },

--- a/package.json
+++ b/package.json
@@ -371,6 +371,14 @@
             {
                 "command": "modalkeys.replayMacro",
                 "title": "ModalKeys: Replay macro"
+            },
+            {
+                "command": "modalkeys.nextKeytip",
+                "title": "ModalKeys: Next Keytip"
+            },
+            {
+                "command": "modalkeys.previousKeytip",
+                "title": "ModalKeys: Previous Keytip"
             }
         ],
         "keybindings": [

--- a/package.json
+++ b/package.json
@@ -87,6 +87,11 @@
                     "description": "A description of each kind of keybinding; determines keybinding color codes (order matters).",
                     "default": {}
                 },
+                "modalkeys.docTips": {
+                    "type": "array",
+                    "description": "A list of quick tips for selected keybindings",
+                    "default": []
+                },
                 "modalkeys.keybindings": {
                     "type": "object",
                     "description": "Keybindings map key → VS Code commands",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,14 @@
                     "icon": "icon.svg",
                     "visibility": "visible"
                 }
+            ],
+            "modalKeyTips": [
+                {
+                    "type": "tree",
+                    "id": "modalkeys.tipView",
+                    "name": "Tips",
+                    "visibility": "visible"
+                }
             ]
         },
         "viewsContainers": {
@@ -59,6 +67,13 @@
                 {
                     "id": "modalKeyBindingView",
                     "title": "Modal Key Bindings",
+                    "icon": "icon.svg"
+                }
+            ],
+            "activitybar": [
+                {
+                    "id": "modalKeyTips",
+                    "title": "Modal-Keybinding Tips",
                     "icon": "icon.svg"
                 }
             ]

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "url": "https://github.com/haberdashPI/vscode-modal-keys"
     },
     "icon": "logo.png",
-    "version": "0.11",
+    "version": "0.11.0",
     "engines": {
         "vscode": "^1.64.0"
     },

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
             "activitybar": [
                 {
                     "id": "modalKeyTips",
-                    "title": "Modal-Keybinding Tips",
+                    "title": "Modal Key",
                     "icon": "icon.svg"
                 }
             ]
@@ -389,7 +389,7 @@
             },
             {
                 "key": "alt+;",
-                "command": "modelkeys.nextKeytip"
+                "command": "modalkeys.nextKeytip"
             },
             {
                 "key": "shift+alt+;",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "url": "https://github.com/haberdashPI/vscode-modal-keys"
     },
     "icon": "logo.png",
-    "version": "0.10.4",
+    "version": "0.11",
     "engines": {
         "vscode": "^1.64.0"
     },

--- a/presets/larkin.js
+++ b/presets/larkin.js
@@ -129,11 +129,14 @@ docTips: [
         modes: [ "normal" ],
         more: [ "notebook", "argument", "select_text" ],
         entries: [
-            { title: "Numbers", id: "number" },
-            { title: "Comments", id: "comment" },
+            { title: "Adjustments", id: "adjust"},
             { title: "Regions", id: "region" },
+            { title: "Comments", id: "comment" },
             { title: "Brackets", id: "bracket" },
             { title: "Indent", id: "indent" },
+            { title: "Quotes", id: "quote"},
+            { title: "Numbers", id: "number" },
+            { title: "Around Chars", id: "around_chars"},
             { note: "Selects around an entire object (e.g. word)", id: 'around_tip' }
         ]
     },
@@ -501,22 +504,21 @@ keybindings: {
     "::doc::}": {kind: 'select', label: 'around indent', detail: 'all text at same indent along with the line above and below this (ala c-like synatx)', tip: "ident"},
     "}": "vscode-select-by-indent.select-outer",
 
-    // TODO: this is where I stopped adding selection commands to `docTips`
-    "::doc::u`": {kind: 'select', label: 'inside ``', detail: 'inside first character pair `` (non syntactical, useful inside comments)'},
+    "::doc::u`": {kind: 'select', label: 'inside ``', detail: 'inside first character pair `` (non syntactical, useful inside comments)', tip: "quote"},
     "u`": { "modalkeys.selectBetween": {
         from: "`", to: "`",
         inclusive: false,
         caseSensitive: true,
         docScope: true
     }},
-    "::doc::u[": {kind: 'select', label: 'inside []', detail: 'inside first character pair `[]` (non syntactical, useful inside comments)'},
+    "::doc::u[": {kind: 'select', label: 'inside []', detail: 'inside first character pair `[]` (non syntactical, useful inside comments)', tip: "bracket"},
     "u[": { "modalkeys.selectBetween": {
         from: "[", to: "]",
         inclusive: false,
         caseSensitive: true,
         docScope: true
     }},
-    "::doc::u{": {kind: 'select', label: 'inside {}', detail: 'inside first character pair `{}` (non syntactical, useful inside comments)'},
+    "::doc::u{": {kind: 'select', label: 'inside {}', detail: 'inside first character pair `{}` (non syntactical, useful inside comments)', tip: "bracket"},
     "u{": { "modalkeys.selectBetween": {
         from: "{", to: "}",
         inclusive: false,
@@ -524,7 +526,7 @@ keybindings: {
         docScope: true
     }},
 
-    "::doc::u[": {kind: 'select', label: 'around []', detail: 'around first character pair `[]` (non syntactical, useful inside comments)'},    
+    "::doc::u]": {kind: 'select', label: 'around []', detail: 'around first character pair `[]` (non syntactical, useful inside comments)', tip: "bracket"},    
     "u]": { "modalkeys.selectBetween": {
         from: "[", to: "]",
         inclusive: true,
@@ -532,7 +534,7 @@ keybindings: {
         docScope: true
     }},
     
-    "::doc::u{": {kind: 'select', label: 'around {}', detail: 'around first character pair `{}` (non syntactical, useful inside comments)'},    
+    "::doc::u}": {kind: 'select', label: 'around {}', detail: 'around first character pair `{}` (non syntactical, useful inside comments)', tip: "bracket"},    
     "u}": { "modalkeys.selectBetween": {
         from: "{", to: "}",
         inclusive: true,
@@ -540,43 +542,43 @@ keybindings: {
         docScope: true
     }},
 
-    "::doc::uC": {kind: 'select', label: 'between bracket pair', detail: 'around/inside some bracket pairs' },
-    "::doc::uC(": {kind: 'select', label: 'inside ()', detail: 'inside first pair of `()` (non syntactical, useful inside comments)' },  
+    "::doc::uC": {kind: 'select', label: 'between bracket pair', detail: 'around/inside some bracket pairs'},
+    "::doc::uC(": {kind: 'select', label: 'inside ()', detail: 'inside first pair of `()` (non syntactical, useful inside comments)', tip: "bracket" },  
     "uC(": { "modalkeys.selectBetween": {
         from: "(", to: ")",
         inclusive: false,
         caseSensitive: true,
         docScope: true
     }},
-    "::doc::uC)": {kind: 'select', label: 'around ()', detail: 'around first pair of `()` (non syntactical, useful inside comments)' },  
+    "::doc::uC)": {kind: 'select', label: 'around ()', detail: 'around first pair of `()` (non syntactical, useful inside comments)', tip: "bracket" },  
     "uC)": { "modalkeys.selectBetween": {
         from: "(", to: ")",
         inclusive: false,
         caseSensitive: true,
         docScope: true
     }},
-    "::doc::uC,": {kind: 'select', label: 'inside <>', detail: 'inside first character pair `<>` (non syntactical, useful inside comments)'},    
+    "::doc::uC,": {kind: 'select', label: 'inside <>', detail: 'inside first character pair `<>` (non syntactical, useful inside comments)', tip: "bracket" },
     "uC.": { "modalkeys.selectBetween": {
         from: "<", to: ">",
         inclusive: false,
         caseSensitive: true,
         docScope: true
     }},
-    "::doc::uC.": {kind: 'select', label: 'inside ><', detail: 'inside first character pair `><` (non syntactical, useful inside comments)'},    
+    "::doc::uC.": {kind: 'select', label: 'inside ><', detail: 'inside first character pair `><` (non syntactical, useful inside comments)', tip: "bracket" },
     "uC.": { "modalkeys.selectBetween": {
         from: ">", to: "<",
         inclusive: false,
         caseSensitive: true,
         docScope: true
     }},
-    "::doc::uC<": {kind: 'select', label: 'around <>', detail: 'around first character pair `<>` (non syntactical, useful inside comments)'},    
+    "::doc::uC<": {kind: 'select', label: 'around <>', detail: 'around first character pair `<>` (non syntactical, useful inside comments)', tip: "bracket" },
     "uC<": { "modalkeys.selectBetween": {
         from: "<", to: ">",
         inclusive: true,
         caseSensitive: true,
         docScope: true
     }},
-    "::doc::uC>": {kind: 'select', label: 'around ><', detail: 'around first character pair `><` (non syntactical, useful inside comments)'},    
+    "::doc::uC>": {kind: 'select', label: 'around ><', detail: 'around first character pair `><` (non syntactical, useful inside comments)', tip: "bracket" },
     "uC>": { "modalkeys.selectBetween": {
         from: ">", to: "<",
         inclusive: true,
@@ -584,7 +586,7 @@ keybindings: {
         docScope: true
     }},
 
-    "::doc::uc": {kind: 'select', label: 'between pair', detail: 'between two instances of any character, exclusive of the pair (non syntatical, useful inside comments)'},
+    "::doc::uc": {kind: 'select', label: 'between pair', detail: 'between two instances of any character, exclusive of the pair (non syntatical, useful inside comments)', tip: "around_chars"},
     uc: { "modalkeys.captureChar": {
         acceptAfter: 1,
         executeAfter: { "modalkeys.selectBetween": {
@@ -596,7 +598,7 @@ keybindings: {
         }},
     }},
 
-    "::doc::uv": {kind: 'select', label: 'around pair', detail: 'between two instance of any character, inclusive of the pair (non syntatical, useful inside comments)'},
+    "::doc::uv": {kind: 'select', label: 'around pair', detail: 'between two instance of any character, inclusive of the pair (non syntatical, useful inside comments)', tip: "around_chars"},
     uv: { "modalkeys.captureChar": {
         acceptAfter: 1,
         executeAfter: { "modalkeys.selectBetween": {
@@ -610,16 +612,16 @@ keybindings: {
 
     // ### Selection Modifiers
 
-    "::doc::normal::R": {kind: "select", label: 'expand no wht', detail: 'select full line(s), and trim external whitespace'},
+    "::doc::normal::R": {kind: "select", label: 'expand no wht', detail: 'select full line(s), and trim external whitespace', tip: "adjust"},
     "normal::R": [ "expandLineSelection", "selection-utilities.trimSelectionWhitespace" ],
-    "::doc::R": {kind: "modifier", label: 'trim whitespace', detail: 'shrink selection to avoid external whitespace'},
+    "::doc::R": {kind: "modifier", label: 'trim whitespace', detail: 'shrink selection to avoid external whitespace', tip: "adjust"},
     "R": "selection-utilities.trimSelectionWhitespace" ,
-    "::doc::U": {kind: "modifier", label: 'narrow to subword', detail: "Narrow current selection so it starts and stops at a subword (e.g. 'snake' in snake_case)"},
+    "::doc::U": {kind: "modifier", label: 'narrow to subword', detail: "Narrow current selection so it starts and stops at a subword (e.g. 'snake' in snake_case)", tip: "adjust"},
     U: { "selection-utilities.narrowTo": { unit: "subident", boundary: "both", } },
 
-    "::doc::r": {kind: "modifier", label: 'clear', detail: "Clear the current selection"},
+    "::doc::r": {kind: "modifier", label: 'clear', detail: "Clear the current selection", tip: "adjust"},
     r: "modalkeys.cancelMultipleSelections",
-    "::doc:: ": {kind: "mode", label: 'hold', detail: "Start visual mode (enabling selection)"},
+    "::doc:: ": {kind: "mode", label: 'hold', detail: "Start visual mode (enabling selection)", tip: "adjust"},
     " ": "modalkeys.enableSelection",
 
     // ### Actions

--- a/presets/larkin.js
+++ b/presets/larkin.js
@@ -95,7 +95,7 @@ docTips: [
         more: [ "advanced", "argument" ],
         entries: [
             { title: "Basic Cursor Movement", id: "cursor" },
-            { title: "Cursor Movement", id: "advanced" },
+            { title: "Cursor Movement", id: "cursor_advanced" },
             { title: "Word Movement", id: "word" },
             { title: "Document Movement", id: "document" },
             { note: "Many additional selection commands", id: "select_leader" },
@@ -120,7 +120,7 @@ docTips: [
         comment: "Selection by searching specific strings",
         id: "search",
         entries: [
-            { title: "By Cursor", id: "cursor" },
+            { title: "By Cursor", id: "search_cursor" },
             { title: "By Character", id: "character" },
             { title: "By String", id: "string" },
             { title: "Iteration", id: "iteration" },
@@ -137,7 +137,7 @@ docTips: [
             { title: "Comments", id: "comment" },
             { title: "Regions", id: "region" },
             { title: "Brackets", id: "bracket" },
-            { title: "Indent", id: "ident" },
+            { title: "Indent", id: "indent" },
             { note: "Selects around an entire object (e.g. word)", id: 'around_tip' }
         ]
     },
@@ -146,12 +146,12 @@ docTips: [
         comment: "Many of hte most useful, more complex text manipulation commands", 
         id: "advanced_text",
         entries: [
-            { title: "Insert", id: "insert" },
-            { title: "Copy/Paste", id: "copy" },
-            { title: "Change brackets", id: "brackets" },
+            { title: "Insert", id: "advanced_insert" },
+            { title: "Copy/Paste", id: "advanced_copy" },
+            { title: "Change brackets", id: "text_bracket" },
             { title: "Change captilization", id: "case" },
-            { title: "Change a number", id: "number" },
-            { title: "Indent Lines", id: "indent" }
+            { title: "Change a number", id: "text_number" },
+            { title: "Indent Lines", id: "text_indent" }
         ]
     },
     { 
@@ -169,10 +169,10 @@ keybindings: {
     // ### Motions
 
     // basic movement
-    "::doc::h": { kind: "select", label: "←", detail: "move left", tip: [ "basic", "cursor" ]},
-    "::doc::j": { kind: "select", label: '↓', detail: "move down", tip: [ "basic", "cursor" ] },
-    "::doc::k": { kind: "select", label: '↑', detail: "move up", tip: [ "basic", "cursor" ] },
-    "::doc::l": { kind: "select", label: '→', detail: "move right", tip: [ "basic", "cursor" ] },
+    "::doc::h": { kind: "select", label: "←", detail: "move left", tip: "cursor"},
+    "::doc::j": { kind: "select", label: '↓', detail: "move down", tip: "cursor" },
+    "::doc::k": { kind: "select", label: '↑', detail: "move up", tip: "cursor" },
+    "::doc::l": { kind: "select", label: '→', detail: "move right", tip: "cursor" },
     "::doc::g": { kind: "leader", label: "actions (mostly)", detail: "additional commands (mostly actions)", tip: "action_leader" },
     "::doc::gj": { kind: "select", label: 'unwrp ↓', detail: "Down unwrapped line"},
     "::doc::gk": { kind: "select", label: 'unwrp ↑', detail: "Up unwrapped line"},
@@ -186,33 +186,33 @@ keybindings: {
     },
 
     // line related movements
-    "::doc::H": { kind: "select", label: "start", detail: "start of line (alterantes between first non-whitepace, and first)", tip: [ "basic", "advanced" ] },
+    "::doc::H": { kind: "select", label: "start", detail: "start of line (alterantes between first non-whitepace, and first)", tip: "cursor_advanced" },
     H: "cursorHomeSelect",
-    "::doc::L": { kind: "select", label: "end", detail: "end of line", tip: [ "basic", "advanced" ] },
+    "::doc::L": { kind: "select", label: "end", detail: "end of line", tip: "cursor_advanced" },
     L: { "cursorMove": { to: "wrappedLineEnd", select: true } },
-    "::doc::G": { kind: "select", label: "expand", detail: "expand selections to full lines", tip: [ "basic", "advanced" ] },
+    "::doc::G": { kind: "select", label: "expand", detail: "expand selections to full lines", tip: "cursor_advanced" },
     G:  "expandLineSelection",
-    "::doc::K": { kind: "select", label: "sel ↑", detail: "select lines upwards", tip: [ "basic", "advanced" ] },    
+    "::doc::K": { kind: "select", label: "sel ↑", detail: "select lines upwards", tip: "cursor_advanced" },    
     K: [
         "modalkeys.cancelMultipleSelections",
         { "cursorMove": { to: 'up', by: 'wrappedLine', select: true, value: '__count' } },
         "expandLineSelection",
         "selection-utilities.activeAtStart"
     ],
-    "::doc::J": { kind: "select", label: "sel ↓", detail: "select lines downwards", tip: [ "basic", "advanced" ] },    
+    "::doc::J": { kind: "select", label: "sel ↓", detail: "select lines downwards", tip: "cursor_advanced" },    
     J: [
         "modalkeys.cancelMultipleSelections",
         { "cursorMove": { to: 'down', by: 'wrappedLine', select: true, value: '__count' } },
         "expandLineSelection",
     ],
-    "::doc::gK": { kind: "select", label: 'unwrp sel ↑', detail: "select unwrapped lines upwards", tip: [ "basic", "advanced" ] },
+    "::doc::gK": { kind: "select", label: 'unwrp sel ↑', detail: "select unwrapped lines upwards", tip: "cursor_advanced" },
     gK: [
         "modalkeys.cancelMultipleSelections",
         { "cursorMove": { to: 'up', by: 'line', select: true, value: '__count' } },
         "expandLineSelection",
         "selection-utilities.activeAtStart"
     ],
-    "::doc::gJ": { kind: "select", label: 'unwrp sel ↓', detail: "select unwrapped lines downwards", tip: [ "basic", "advanced" ] },
+    "::doc::gJ": { kind: "select", label: 'unwrp sel ↓', detail: "select unwrapped lines downwards", tip: "cursor_advanced" },
     gJ: [
         "modalkeys.cancelMultipleSelections",
         { "cursorMove": { to: 'down', by: 'line', select: true, value: '__count' } },
@@ -220,54 +220,54 @@ keybindings: {
     ],
 
 
-    "::doc::\\": { kind: "select", label: 'right character', detail: "select *just* the character to the right", tip: [ "basic", "advanced" ] },
+    "::doc::\\": { kind: "select", label: 'right character', detail: "select *just* the character to the right", tip: "cursor_advanced" },
     "\\": [
         "modalkeys.cancelMultipleSelections",
         { "cursorMove": { to: 'right', select: true, value: '__count' } }
     ],
-    "::doc::|": { kind: "select", label: 'left character', detail: "select *just* the character to the left", tip: [ "basic", "advanced" ] },
+    "::doc::|": { kind: "select", label: 'left character', detail: "select *just* the character to the left", tip: "cursor_advanced" },
     "|": [
         "modalkeys.cancelMultipleSelections",
         { "cursorMove": { to: 'left', select: true, value: '__count' } }
     ],
 
     // movements around regex units
-    "::doc::'": { kind: "leader", label: "select (mostly)", detail: "additional commands (mostly selection/view related)", tip: [ "select_leader" ]},
-    "::doc::u": { kind: "leader", label: "around", detail: "selection commands that move start and end of a selection to surround the entire object (rather than extending to specified start/end point)", tip: [ "around_tip" ] },
+    "::doc::'": { kind: "leader", label: "select (mostly)", detail: "additional commands (mostly selection/view related)", tip: "select_leader"},
+    "::doc::u": { kind: "leader", label: "around", detail: "selection commands that move start and end of a selection to surround the entire object (rather than extending to specified start/end point)", tip: "around_tip" },
     "::doc::u'": { kind: "leader", label: "select", detail: "additional selections"},
-    "::doc::w": { kind: "select", label: "subwrd →", detail: "next subword (camel/snake case)", tip: [ "basic", "word" ] },
-    "::doc::W": { kind: "select", label: "word →", detail: "next word", tip: [ "basic", "word" ]},
-    "::doc::e": { kind: "select", label: "word end →", detail: "next word end", tip: [ "basic", "word" ] },
-    "::doc::b": { kind: "select", label: "subwrd ←", detail: "previous subword (came/snake case)", tip: [ "basic", "word" ] },
-    "::doc::B": { kind: "select", label: "word ←", detail: "previous word", tip: [ "basic", "word" ] },
-    "::doc::E": { kind: "select", label: "word end ←", detail: "previous word end", tip: [ "basic", "word" ] },
+    "::doc::w": { kind: "select", label: "subwrd →", detail: "next subword (camel/snake case)", tip: "word" },
+    "::doc::W": { kind: "select", label: "word →", detail: "next word", tip: "word"},
+    "::doc::e": { kind: "select", label: "word end →", detail: "next word end", tip: "word" },
+    "::doc::b": { kind: "select", label: "subwrd ←", detail: "previous subword (came/snake case)", tip: "word" },
+    "::doc::B": { kind: "select", label: "word ←", detail: "previous word", tip: "word" },
+    "::doc::E": { kind: "select", label: "word end ←", detail: "previous word end", tip: "word" },
     "::doc::uw": { kind: "select", label: "subwrd →", detail: "select entire subword with and trailing whitespace (camel/snake case)" },
     "::doc::uW": { kind: "select", label: "word →", detail: "select entire word and trailing whitespace"},
     "::doc::ue": { kind: "select", label: "in word →", detail: "select entire word (no whitespace)" },
     "::doc::ub": { kind: "select", label: "subwrd ←", detail: "select previous subword and trailing whitespace (came/snake case)" },
     "::doc::uB": { kind: "select", label: "word ←", detail: "select previous word and trailing whitespace" },
     "::doc::uE": { kind: "select", label: "in word ←", detail: "select previous word (no whitespace)" },    
-    "::doc::@": { kind: "select", label: "number ←", detail: "next number", tip: [ "advanced", "number" ] },
-    "::doc::#": { kind: "select", label: "number →", detail: "previous number", tip: [ "advanced", "number" ] },
-    "::doc::';": { kind: "select", label: "comment →", detail: "next commented region" , tip: [ "advanced", "comment" ]},
-    "::doc::':": { kind: "select", label: "comment ←", detail: "previous commented region" , tip: [ "advanced", "comment" ]},
-    "::doc::,;": { kind: "select", label: "blk commt →", detail: "next block commented region" , tip: [ "advanced", "comment" ]},
-    "::doc::,:": { kind: "select", label: "blk commt ←", detail: "previous block commented region" , tip: [ "advanced", "comment" ]},
-    "::doc::p": { kind: "select", label: "pargrph →", detail: "next pagaraph", tip: [ "advanced", "region" ] },
-    "::doc::P": { kind: "select", label: "pargrph ←", detail: "previous paragraph", tip: [ "advanced", "region" ] },
-    "::doc::')": { kind: "select", label: "sec →", detail: "next section", tip: [ "advanced", "region" ] },
-    "::doc::'(": { kind: "select", label: "sec ←", detail: "previous section", tip: [ "advanced", "region" ] },
-    "::doc::)": { kind: "select", label: "subsec →", detail: "next subsection", tip: [ "advanced", "region" ] },
-    "::doc::(": { kind: "select", label: "subsec ←", detail: "previous subsection", tip: [ "advanced", "region" ] },
+    "::doc::@": { kind: "select", label: "number ←", detail: "next number", tip: "number" },
+    "::doc::#": { kind: "select", label: "number →", detail: "previous number", tip: "number" },
+    "::doc::';": { kind: "select", label: "comment →", detail: "next commented region" , tip: "comment"},
+    "::doc::':": { kind: "select", label: "comment ←", detail: "previous commented region" , tip: "comment"},
+    "::doc::,;": { kind: "select", label: "blk commt →", detail: "next block commented region" , tip: "comment"},
+    "::doc::,:": { kind: "select", label: "blk commt ←", detail: "previous block commented region" , tip: "comment"},
+    "::doc::p": { kind: "select", label: "pargrph →", detail: "next pagaraph", tip: "region" },
+    "::doc::P": { kind: "select", label: "pargrph ←", detail: "previous paragraph", tip: "region" },
+    "::doc::')": { kind: "select", label: "sec →", detail: "next section", tip: "region" },
+    "::doc::'(": { kind: "select", label: "sec ←", detail: "previous section", tip: "region" },
+    "::doc::)": { kind: "select", label: "subsec →", detail: "next subsection", tip: "region" },
+    "::doc::(": { kind: "select", label: "subsec ←", detail: "previous subsection", tip: "region" },
     "::doc::up": { kind: "select", label: "pargrph →", detail: "next pagaraph" },
     "::doc::uP": { kind: "select", label: "pargrph ←", detail: "previous paragraph" },
     "::doc::u')": { kind: "select", label: "sec →", detail: "next section" },
     "::doc::u'(": { kind: "select", label: "sec ←", detail: "previous section" },
     "::doc::u)": { kind: "select", label: "subsec →", detail: "next subsection" },
     "::doc::u(": { kind: "select", label: "subsec ←", detail: "previous subsection" },
-    "::doc::'w": { kind: "select", label: "WORD →", detail: "next WORD; e.g. contiguous non-whitespace region", tip: [ "basic", "word" ]},
-    "::doc::'b": { kind: "select", label: "WORD ←", detail: "previous WORD; e.g. contiguous non-whitespace region", tip: [ "basic", "word" ]},
-    "::doc::'e": { kind: "select", label: "WORD end →", detail: "to end of WORD; e.g. contiguous non-whitespace region", tip: [ "basic", "word" ]},
+    "::doc::'w": { kind: "select", label: "WORD →", detail: "next WORD; e.g. contiguous non-whitespace region", tip: "word"},
+    "::doc::'b": { kind: "select", label: "WORD ←", detail: "previous WORD; e.g. contiguous non-whitespace region", tip: "word"},
+    "::doc::'e": { kind: "select", label: "WORD end →", detail: "to end of WORD; e.g. contiguous non-whitespace region", tip: "word"},
     "::doc::u'w": { kind: "select", label: "WORD →", detail: "select entire WORD and trailing whitespace; a WORD is a contiguous non-whitespace region" },
     "::doc::u'e": { kind: "select", label: "WORD →", detail: "select entire WORD; a WORD is a contiguous non-whitespace region" },
 
@@ -318,49 +318,49 @@ keybindings: {
     },
 
     // jupyter based cell selection
-    "::doc::'y": { kind: "select", label: "jupyter", detail: "jupyter related selection commands", tip: [ "notebook" ]},
-    "::doc::'yc": { kind: "select", label: "cell →", detail: "next jupyter notebook cell", tip: [ "notebook" ]},
+    "::doc::'y": { kind: "select", label: "jupyter", detail: "jupyter related selection commands", tip: "notebook"},
+    "::doc::'yc": { kind: "select", label: "cell →", detail: "next jupyter notebook cell", tip: "notebook"},
     "'yc": ["jupyter.gotoNextCellInFile", "jupyter.selectCell"],
-    "::doc::'yC": { kind: "select", label: "cell ←", detail: "previous jupyter notebook cell", tip: [ "notebook" ]},
+    "::doc::'yC": { kind: "select", label: "cell ←", detail: "previous jupyter notebook cell", tip: "notebook"},
     "'yC": ["jupyter.gotoPrevCellInFile", "jupyter.selectCell"],
-    "::doc::uy": { kind: "select", label: "cell", detail: "select a jyputer notebook cell", tip: [ "notebook" ]},
+    "::doc::uy": { kind: "select", label: "cell", detail: "select a jyputer notebook cell", tip: "notebook"},
     uy: "jupyter.selectCell",
 
     // function arguments
     "::doc::,": { kind: "leader", label: "window (mostly)", detail: "additional commands, mostly related to changes to the editor/view/window" },
     "::using::move-cursor-by-argument.move-by-argument": {
-        "::doc::,w": { kind: "select", label: "arg →", detail: "Next function argument", tip: [ "argument" ]},
+        "::doc::,w": { kind: "select", label: "arg →", detail: "Next function argument", tip: "argument"},
         ",w":  { value: "(__count || 1)",  boundary: "end", select:      true },
-        "::doc::,b": { kind: "select", label: "arg ←", detail: "Previous function argument", tip: [ "argument" ]},
+        "::doc::,b": { kind: "select", label: "arg ←", detail: "Previous function argument", tip: "argument"},
         ",b":  { value: "-(__count || 1)", boundary: "start", select:      true },
-        "::doc::,W": { kind: "select", label: "arg(+,) →", detail: "Next function argument (and comma)", tip: [ "argument" ]},
+        "::doc::,W": { kind: "select", label: "arg(+,) →", detail: "Next function argument (and comma)", tip: "argument"},
         ",W":  { value: "(__count || 1)",  boundary: "start", select:      true },
-        "::doc::,B": { kind: "select", label: "arg(+,) ←", detail: "Previous function argument (and comma)", tip: [ "argument" ]},
+        "::doc::,B": { kind: "select", label: "arg(+,) ←", detail: "Previous function argument (and comma)", tip: "argument"},
         ",B":  { value: "-(__count || 1)", boundary: "end",   select:      true },
-        "::doc::u.": { kind: 'select', label: "arg →", detail: "Around next argument", tip: [ "argument" ]},
+        "::doc::u.": { kind: 'select', label: "arg →", detail: "Around next argument", tip: "argument"},
         "u.": { value: "(__count || 1)",  boundary: "both", selectWhole: true },
-        "::doc::u,": { kind: 'select', label: "arg ←", detail: "Around previous argument", tip: [ "argument" ]},
+        "::doc::u,": { kind: 'select', label: "arg ←", detail: "Around previous argument", tip: "argument"},
         "u,": { value: "-(__count || 1)", boundary: "both", selectWhole: true },
-        "::doc::u>": { kind: 'select', label: "arg →", detail: "Around next argument (with comma)", tip: [ "argument" ]},
+        "::doc::u>": { kind: 'select', label: "arg →", detail: "Around next argument (with comma)", tip: "argument"},
         "u>": { value: "(__count || 1)",  boundary: "start", selectWhole: true },
-        "::doc::u<": { kind: 'select', label: "arg ←", detail: "Around previous argument (with comma)", tip: [ "argument" ]},
+        "::doc::u<": { kind: 'select', label: "arg ←", detail: "Around previous argument (with comma)", tip: "argument"},
         "u<": { value: "-(__count || 1)", boundary: "end",   selectWhole: true },
     },
 
     // generic, magic selection
-    "::doc::uu": { kind: 'select', label: "smart expand", detail: "Use VSCode's built-in smart expansion command", tip: [ "advanced", "region" ]},
+    "::doc::uu": { kind: 'select', label: "smart expand", detail: "Use VSCode's built-in smart expansion command", tip: "region"},
     "uu": "editor.action.smartSelect.expand",
 
     // buffer related
-    "::doc::$": { kind: "select", label: "all", detail: "Select the entire document", tip: [ "basic", "document" ] },
+    "::doc::$": { kind: "select", label: "all", detail: "Select the entire document", tip: "document" },
     $: [ "editor.action.selectAll" ],
-    "::doc::gG": { kind: 'select', label: 'doc end', tip: [ "basic", "document" ] },
+    "::doc::gG": { kind: 'select', label: 'doc end', tip: "document" },
     "gG": "cursorBottomSelect",
-    "::doc::gg": { kind: 'select', label: 'doc start', tip: [ "basic", "document" ] },
+    "::doc::gg": { kind: 'select', label: 'doc start', tip: "document" },
     "gg": "cursorTopSelect",
 
     // search related
-    "::doc::*": { kind: "select", label: "match →", detail: "Next match to object under cursor", tip: [ "search", "cursor" ]},
+    "::doc::*": { kind: "select", label: "match →", detail: "Next match to object under cursor", tip:  "search_cursor" },
     "*": [
         { "modalkeys.search": {
             text: "__wordstr",
@@ -368,7 +368,7 @@ keybindings: {
             register: "search"
         }}
     ],
-    "::doc::&": { kind: "select", label: "match ←", detail: "Previous match to object under cursor", tip: [ "search", "cursor" ]},
+    "::doc::&": { kind: "select", label: "match ←", detail: "Previous match to object under cursor", tip:  "search_cursor" },
     "&": [
         { "modalkeys.search": {
             text: "__wordstr",
@@ -378,12 +378,12 @@ keybindings: {
         }}
     ],
 
-    "::doc::n": { kind: "select", label: "search →", detail: "Next match to search term", tip: [ "search", "iteration" ]},
+    "::doc::n": { kind: "select", label: "search →", detail: "Next match to search term", tip: "iteration"},
     "n": { "modalkeys.nextMatch": {register: "search"}, repeat: "__count" },
-    "::doc::N": { kind: "select", label: "search →", detail: "Previous match to search term", tip: [ "search", "iteration" ]},
+    "::doc::N": { kind: "select", label: "search →", detail: "Previous match to search term", tip: "iteration"},
     "N": { "modalkeys.previousMatch": {register: "search"}, repeat: "__count" },
 
-    "::doc::/": { kind: "select", label: "search", detail: "Search forwards", tip: [ "search", "string" ]},
+    "::doc::/": { kind: "select", label: "search", detail: "Search forwards", tip: "string"},
     "/": { "modalkeys.search": {
         register: "search",
         caseSensitive: true,
@@ -391,7 +391,7 @@ keybindings: {
         selectTillMatch: true,
         wrapAround: true
     } },
-    "::doc::?": { kind: "select", label: "search back", detail: "Search backward", tip: [ "search", "string" ]},
+    "::doc::?": { kind: "select", label: "search back", detail: "Search backward", tip: "string"},
     "?": { "modalkeys.search": {
         register: "search",
         caseSensitive: true,
@@ -400,7 +400,7 @@ keybindings: {
         wrapAround: true
     } },
 
-    "::doc::f": { kind: "select", label: "find char", detail: "To next char (include char in selection)", tip: [ "search", "character" ]},
+    "::doc::f": { kind: "select", label: "find char", detail: "To next char (include char in selection)", tip: "character"},
     f: { "modalkeys.search": {
         caseSensitive: true,
         acceptAfter: 1,
@@ -408,7 +408,7 @@ keybindings: {
         selectTillMatch: true,
         wrapAround: true
     }},
-    "::doc::F": { kind: "select", label: "find char back", detail: "To previous character (include char in selection)", tip: [ "search", "character" ]},
+    "::doc::F": { kind: "select", label: "find char back", detail: "To previous character (include char in selection)", tip: "character"},
     F: { "modalkeys.search": {
         caseSensitive: true,
         acceptAfter: 1,
@@ -416,7 +416,7 @@ keybindings: {
         selectTillMatch: true,
         wrapAround: true
     }},
-    "::doc::t": { kind: "select", label: "find char", detail: "To next character (exclude char in selection)", tip: [ "search", "character" ]},
+    "::doc::t": { kind: "select", label: "find char", detail: "To next character (exclude char in selection)", tip: "character"},
     t: { "modalkeys.search": {
         caseSensitive: true,
         acceptAfter: 1,
@@ -425,7 +425,7 @@ keybindings: {
         offset: 'start',
         wrapAround: true
     }},
-    "::doc::T": { kind: "select", label: "find char back", detail: "To previous character (exclude char in selection)", tip: [ "search", "character" ]},
+    "::doc::T": { kind: "select", label: "find char back", detail: "To previous character (exclude char in selection)", tip: "character"},
     T: { "modalkeys.search": {
         caseSensitive: true,
         acceptAfter: 1,
@@ -434,7 +434,7 @@ keybindings: {
         offset: 'end',
         wrapAround: true
     }},
-    "::doc::s": { kind: "select", label: "find char pair", detail: "To next character pair", tip: [ "search", "character" ]},
+    "::doc::s": { kind: "select", label: "find char pair", detail: "To next character pair", tip: "character"},
     s: { "modalkeys.search": {
         caseSensitive: true,
         acceptAfter: 2,
@@ -443,7 +443,7 @@ keybindings: {
         offset: 'start',
         wrapAround: true
     }},
-    "::doc::S": { kind: "select", label: "char pair back", detail: "To previous character pair", tip: [ "search", "character" ]},
+    "::doc::S": { kind: "select", label: "char pair back", detail: "To previous character pair", tip: "character"},
     S: { "modalkeys.search": {
         casSensitive: true,
         acceptAfter: 2,
@@ -452,21 +452,21 @@ keybindings: {
         offset: 'start',
         wrapAround: true
     }},
-    "::doc::;": {kind: "select", label: "→ match", detail: "Repeat search motion forwards (for `f`, `t`, etc...)", tip: [ "search", "iteration" ]},
+    "::doc::;": {kind: "select", label: "→ match", detail: "Repeat search motion forwards (for `f`, `t`, etc...)", tip: "iteration"},
     ";": { "modalkeys.nextMatch": {}, repeat: "__count" },
-    "::doc:::": {kind: "select", label: "← match", detail: "Repeat search motion backwards (for `f`, `t`, etc...)", tip: [ "search", "iteration" ]},
+    "::doc:::": {kind: "select", label: "← match", detail: "Repeat search motion backwards (for `f`, `t`, etc...)", tip: "iteration"},
     ":": { "modalkeys.previousMatch": {}, repeat: "__count" },
 
     // ### more complex syntactic selections
 
-    "::doc::%": { kind: 'select', label: 'to bracket', detail: "Move to matching bracket", tip: [ "advanced", "bracket" ]},
+    "::doc::%": { kind: 'select', label: 'to bracket', detail: "Move to matching bracket", tip: "bracket"},
     '%': "editor.action.jumpToBracket",
-    "::doc::''": {kind: 'select', label: 'in quotes', detail: "text within current quotes", tip: [ "advanced", "bracket" ]},
+    "::doc::''": {kind: 'select', label: 'in quotes', detail: "text within current quotes", tip: "bracket"},
     "''": "bracketeer.selectQuotesContent",
-    "::doc::'\"": {kind: 'select', label: 'around quotes', detail: "quotes and text within current quotes", tip: [ "advanced", "bracket" ]},
+    "::doc::'\"": {kind: 'select', label: 'around quotes', detail: "quotes and text within current quotes", tip: "bracket"},
     "'\"": ["bracketeer.selectQuotesContent", "bracketeer.selectQuotesContent"],
     // the below is a bit hacky; I want to add these commandsto my extension
-    "::doc::[": {kind: 'select', label: 'in parens', detail: 'text inside parents/brackets/braces', tip: [ "advanced", "bracket" ]},
+    "::doc::[": {kind: 'select', label: 'in parens', detail: 'text inside parents/brackets/braces', tip: "bracket"},
     "[": [
         {
             if: "!__selection.isEmpty",
@@ -479,7 +479,7 @@ keybindings: {
         },
         { "editor.action.selectToBracket": {"selectBrackets": false} }
     ],
-    "::doc::{": {kind: 'select', label: 'arnd parens', detail: 'parents/brackets/braces and their contents', tip: [ "advanced", "bracket" ]},
+    "::doc::{": {kind: 'select', label: 'arnd parens', detail: 'parents/brackets/braces and their contents', tip: "bracket"},
     "{": [
         {
             if: "!__selection.isEmpty",
@@ -493,16 +493,16 @@ keybindings: {
         { "editor.action.selectToBracket": {"selectBrackets": true} }
     ],
 
-    "::doc::'>": { kind: 'select', label: 'in <>', detail: 'text inside angle brackets', tip: [ "advanced", "bracket" ]},
+    "::doc::'>": { kind: 'select', label: 'in <>', detail: 'text inside angle brackets', tip: "bracket"},
     "'>": "extension.selectAngleBrackets",
-    "::doc::'<": { kind: 'select', label: 'in ><', detail: 'text inside tag pairs (e.g. <a>text</a>)', tip: [ "advanced", "bracket" ]},
+    "::doc::'<": { kind: 'select', label: 'in ><', detail: 'text inside tag pairs (e.g. <a>text</a>)', tip: "bracket"},
     "'<": "extension.selectInTag",
 
-    "::doc::']": {kind: 'select', label: 'indent+top', detail: 'all text at same indent and the unindent line just above it (ala python syntax)', tip: [ "advanced", "ident" ]},
+    "::doc::']": {kind: 'select', label: 'indent+top', detail: 'all text at same indent and the unindent line just above it (ala python syntax)', tip: "ident"},
     "']": "vscode-select-by-indent.select-outer-top-only",
-    "::doc::]": {kind: 'select', label: 'inside indent', detail: 'all text at same indent', tip: [ "advanced", "ident" ]},
+    "::doc::]": {kind: 'select', label: 'inside indent', detail: 'all text at same indent', tip: "ident"},
     "]": "vscode-select-by-indent.select-inner",
-    "::doc::}": {kind: 'select', label: 'around indent', detail: 'all text at same indent along with the line above and below this (ala c-like synatx)', tip: [ "advanced", "ident" ]},
+    "::doc::}": {kind: 'select', label: 'around indent', detail: 'all text at same indent along with the line above and below this (ala c-like synatx)', tip: "ident"},
     "}": "vscode-select-by-indent.select-outer",
 
     // TODO: this is where I stopped adding selection commands to `docTips`
@@ -629,22 +629,22 @@ keybindings: {
     // ### Actions
 
     // #### Insert/append text
-    "::doc::i": {kind: "mode", label: 'insert', detail: "Switch to insert mode" , tip: [ "enter_text", "insert" ]},
+    "::doc::i": {kind: "mode", label: 'insert', detail: "Switch to insert mode" , tip: "insert"},
     i: [ "modalkeys.cancelMultipleSelections", "modalkeys.enterInsert" ],
-    "::doc::a": {kind: "mode", label: 'append', detail: "Switch to insert mode, moving cursor to end of current character" , tip: [ "text", "insert" ]},
+    "::doc::a": {kind: "mode", label: 'append', detail: "Switch to insert mode, moving cursor to end of current character" , tip: "insert"},
     a: [ "modalkeys.cancelMultipleSelections", { if: "__char != ''", then: "cursorRight" }, "modalkeys.enterInsert"],
 
-    "::doc::I": {kind: "mode", label: 'insert start', detail: "Switch to insert mode, moving cursor to start of line" , tip: [ "text", "insert" ]},
+    "::doc::I": {kind: "mode", label: 'insert start', detail: "Switch to insert mode, moving cursor to start of line" , tip: "insert"},
     I: [
         { "cursorMove": { to: "wrappedLineFirstNonWhitespaceCharacter", select: false } },
         "modalkeys.enterInsert",
     ],
 
-    "::doc::A": {kind: "mode", label: 'append eol', detail: "Switch to insert mode, moving cursor to end of line" , tip: [ "text", "insert" ]},
+    "::doc::A": {kind: "mode", label: 'append eol', detail: "Switch to insert mode, moving cursor to end of line" , tip: "insert"},
     A: [ { "cursorMove": { to: "wrappedLineEnd", select: false } }, "modalkeys.enterInsert", ],
 
     // #### Text Changes
-    "::doc::c": {kind: "mode", label: 'change', detail: "Delete all selected text and move to insert mode", tip: [ "text", "change" ]},
+    "::doc::c": {kind: "mode", label: 'change', detail: "Delete all selected text and move to insert mode", tip: "change"},
     c: countSelectsLines('down', {
         if: "!__selection.isSingleLine && __selection.end.character == 0 && __selection.start.character == 0",
         // multi-line selection
@@ -671,7 +671,7 @@ keybindings: {
         "modalkeys.enterInsert"
     ]),
 
-    "::doc::C": {kind: "mode", label: 'change to eol', detail: "Delete all text from here to end of line, and switch to insert mode", tip: [ "text", "change" ]},
+    "::doc::C": {kind: "mode", label: 'change to eol', detail: "Delete all text from here to end of line, and switch to insert mode", tip: "change"},
     C: countSelectsLines('up', [
         "modalkeys.cancelMultipleSelections",
         "deleteAllRight",
@@ -683,41 +683,41 @@ keybindings: {
         "modalkeys.enterInsert"
     ]),
 
-    "::doc::gy": {kind: "action", label: 'join', detail: "Remove newline between current and next line", tip: [ "text", "change" ]},
+    "::doc::gy": {kind: "action", label: 'join', detail: "Remove newline between current and next line", tip: "change"},
     "gy": countSelectsLines('down', "editor.action.joinLines"),
 
-    "::doc::`": {kind: "action", label: 'swap', detail: "Swap the style of the current selection or the identifier under the cursor (e.g. from camelCase to snake_case)", tip: [ "advanced_text", "case" ]},
-    "::doc::`c": {kind: "action", label: 'camel', detail: "Swap style to lower camel case (`camelCase`)", tip: [ "advanced_text", "case" ]},
+    "::doc::`": {kind: "action", label: 'swap', detail: "Swap the style of the current selection or the identifier under the cursor (e.g. from camelCase to snake_case)", tip: "case"},
+    "::doc::`c": {kind: "action", label: 'camel', detail: "Swap style to lower camel case (`camelCase`)", tip: "case"},
     "`c": "extension.changeCase.camel",
-    "::doc::`U": {kind: "action", label: 'constant', detail: "Swap style to constant (`IS_CONSTANT`)", tip: [ "advanced_text", "case" ]},
+    "::doc::`U": {kind: "action", label: 'constant', detail: "Swap style to constant (`IS_CONSTANT`)", tip: "case"},
     "`U": "extension.changeCase.constant",
-    "::doc::`.": {kind: "action", label: 'dot', detail: "Swap style to dot case (`dot.case`)", tip: [ "advanced_text", "case" ]},
+    "::doc::`.": {kind: "action", label: 'dot', detail: "Swap style to dot case (`dot.case`)", tip: "case"},
     "`.": "extension.changeCase.dot",
-    "::doc::`-": {kind: "action", label: 'kebab', detail: "Swap style to kebab case (`kebab-case`)", tip: [ "advanced_text", "case" ]},
+    "::doc::`-": {kind: "action", label: 'kebab', detail: "Swap style to kebab case (`kebab-case`)", tip: "case"},
     "`-": "extension.changeCase.kebab",
-    "::doc::`L": {kind: "action", label: 'all lower', detail: "Swap all to lower case", tip: [ "advanced_text", "case" ]},
+    "::doc::`L": {kind: "action", label: 'all lower', detail: "Swap all to lower case", tip: "case"},
     "`L": "extension.changeCase.lower",
-    "::doc::`l": {kind: "action", label: 'first lower', detail: "Swap first letter to lower case", tip: [ "advanced_text", "case" ]},
+    "::doc::`l": {kind: "action", label: 'first lower', detail: "Swap first letter to lower case", tip: "case"},
     "`l": "extension.changeCase.lowerFirst",
-    "::doc::` ": {kind: "action", label: 'spaces', detail: "Swap to spaces (`camelCase` -> `camel case`)", tip: [ "advanced_text", "case" ]},
+    "::doc::` ": {kind: "action", label: 'spaces', detail: "Swap to spaces (`camelCase` -> `camel case`)", tip: "case"},
     "` ": "extension.changeCase.no",
-    "::doc::`C": {kind: "action", label: 'Camel', detail: "Swap to uper camel case (`CamelCase`)", tip: [ "advanced_text", "case" ]},
+    "::doc::`C": {kind: "action", label: 'Camel', detail: "Swap to uper camel case (`CamelCase`)", tip: "case"},
     "`C": "extension.changeCase.pascal",
-    "::doc::`/": {kind: "action", label: 'path', detail: "Swap to 'path' case (`path/case`)", tip: [ "advanced_text", "case" ]},
+    "::doc::`/": {kind: "action", label: 'path', detail: "Swap to 'path' case (`path/case`)", tip: "case"},
     "`/": "extension.changeCase.path",
-    "::doc::`_": {kind: "action", label: 'snake', detail: "Swap to snake case (`snake_case`)", tip: [ "advanced_text", "case" ]},
+    "::doc::`_": {kind: "action", label: 'snake', detail: "Swap to snake case (`snake_case`)", tip: "case"},
     "`_": "extension.changeCase.snake",
-    "::doc::`s": {kind: "action", label: 'swap', detail: "Swap upper and lower case letters", tip: [ "advanced_text", "case" ]},
+    "::doc::`s": {kind: "action", label: 'swap', detail: "Swap upper and lower case letters", tip: "case"},
     "`s": "extension.changeCase.swap",
-    "::doc::`t": {kind: "action", label: 'title', detail: "Swap to title case (all words have first upper case letter)", tip: [ "advanced_text", "case" ]},
+    "::doc::`t": {kind: "action", label: 'title', detail: "Swap to title case (all words have first upper case letter)", tip: "case"},
     "`t": "extension.changeCase.title",
-    "::doc::`Y": {kind: "action", label: 'all upper', detail: "Swap to use all upper case letters", tip: [ "advanced_text", "case" ]},
+    "::doc::`Y": {kind: "action", label: 'all upper', detail: "Swap to use all upper case letters", tip: "case"},
     "`Y": "extension.changeCase.upper",
-    "::doc::`u": {kind: "action", label: 'first upper', detail: "Swap first character to upper case", tip: [ "advanced_text", "case" ]},
+    "::doc::`u": {kind: "action", label: 'first upper', detail: "Swap first character to upper case", tip: "case"},
     "`u": "extension.changeCase.upperFirst",
-    "::doc::``": {kind: "action", label: 'toggle', detail: "Toggle through all possible cases", tip: [ "advanced_text", "case" ]},
+    "::doc::``": {kind: "action", label: 'toggle', detail: "Toggle through all possible cases", tip: "case"},
     "``": "extension.toggleCase",
-    "::doc::~": {kind: "action", label: 'swap char', detail: "Swap case of character under the curser", tip: [ "advanced_text", "case" ]},
+    "::doc::~": {kind: "action", label: 'swap char', detail: "Swap case of character under the curser", tip: "case"},
     "~": [
         "modalkeys.cancelMultipleSelections",
         { "cursorMove": { to: 'right', select: true, value: '__count' } },
@@ -731,7 +731,7 @@ keybindings: {
     ],
 
     // #### Update numerical selections
-    "::doc::=": {kind: "action", label: 'inc #', detail: "Increment a number by 1 (increases increment for subsequent selections)", tip: [ "advanced_text", "number" ]},
+    "::doc::=": {kind: "action", label: 'inc #', detail: "Increment a number by 1 (increases increment for subsequent selections)", tip: "text_number"},
     "=": [
         {
             if: "__selections.length === 1",
@@ -739,7 +739,7 @@ keybindings: {
             else: "extension.incrementSelection",
         },
     ],
-    "::doc::+": {kind: "action", label: 'dec #', detail: "Decrement a number by 1 (increases increment for subsequent selections)", tip: [ "advanced_text", "number" ]},
+    "::doc::+": {kind: "action", label: 'dec #', detail: "Decrement a number by 1 (increases increment for subsequent selections)", tip: "text_number"},
     "+": [
         {
             if: "__selections.length === 1",
@@ -747,9 +747,9 @@ keybindings: {
             else: "extension.decrementSelection",
         },
     ],
-    "::doc::g=": {kind: "action", label: 'inc all #', detail: "Increment all numbers by 1", tip: [ "advanced_text", "number" ]},
+    "::doc::g=": {kind: "action", label: 'inc all #', detail: "Increment all numbers by 1", tip: "text_number"},
     "g=": "editor.emmet.action.incrementNumberByOne",
-    "::doc::g+": {kind: "action", label: 'dec all #', detail: "Decrement all numbers by 1", tip: [ "advanced_text", "number" ]},
+    "::doc::g+": {kind: "action", label: 'dec all #', detail: "Decrement all numbers by 1", tip: "text_number"},
     "g+": "editor.emmet.action.decrementNumberByOne",
 
     // #### Checkmarks
@@ -761,17 +761,17 @@ keybindings: {
     "ga": "selection-utilities.trimWhitespace",
 
     // #### Brackets
-    "::doc::gx": {kind: "action", label: 'remove pair', detail: "Delete a pairing (e.g. `()`)", tip: [ "advanced_text", "brackets" ]},
+    "::doc::gx": {kind: "action", label: 'remove pair', detail: "Delete a pairing (e.g. `()`)", tip: "text_bracket"},
     "::doc::gx[": {kind: "action", label: 'parens/brackets', detail: "Removes pairs that start with `[`, `(` or `{`"},
     "gx[":  "bracketeer.removeBrackets",
-    "::doc::gs": {kind: "action", label: 'swap pair', detail: "Change between different kinds of pairs (e.g. `(` to `{`)", tip: [ "advanced_text", "brackets" ]},
+    "::doc::gs": {kind: "action", label: 'swap pair', detail: "Change between different kinds of pairs (e.g. `(` to `{`)", tip: "text_bracket"},
     "::doc::gs[": {kind: "action", label: 'parens/brackets', detail: "Swap between `[`, `(` and `{`"},
     "gs[":  "bracketeer.swapBrackets",
     "::doc::gs'": {kind: "action", label: 'quotes', detail: "Change between different quotes"},
     "gs'":  "bracketeer.swapQuotes",
     "::doc::gx'": {kind: "action", label: 'quotes', detail: "Removes quotes (', \" or `)"},
     "gx'":  "bracketeer.removeQuotes",
-    "::doc::gi": {kind: "action", label: 'insert pair', detail: "Insert a pairing (e.g. ()) around a selection", tip: [ "advanced_text", "brackets" ]},
+    "::doc::gi": {kind: "action", label: 'insert pair', detail: "Insert a pairing (e.g. ()) around a selection", tip: "text_bracket"},
     "::doc::gi(": {kind: "action", label: 'paren', detail: "Insert parenthesis around selection"},
     "gi(": [ "modalkeys.enterInsert", { "type": { text: "(" }, }, "modalkeys.enterNormal" ],
     "::doc::gi(": {kind: "action", label: 'paren', detail: "Insert parenthesis around selection"},
@@ -791,13 +791,13 @@ keybindings: {
 
     // #### Clipboard 
 
-    "::doc::d": {kind: "action", label: "delete", detail: "Delete selection and save to paste buffer", tip: [ "text", "delete" ]},
+    "::doc::d": {kind: "action", label: "delete", detail: "Delete selection and save to paste buffer", tip: "delete"},
     d: countSelectsLines('down', [
         "editor.action.clipboardCutAction",
         { "modalkeys.enterMode": { mode: "normal" } }, // modalkeys.enterNormal has async issues that cause the entire line to be deleted here
     ]),
 
-    "::doc::D": {kind: "action", label: "delete (eol/up)", detail: "without count: Delete from cursor to end of line; with count: Delete from current line up `count` number of keys.", tip: [ "text", "delete" ]},
+    "::doc::D": {kind: "action", label: "delete (eol/up)", detail: "without count: Delete from cursor to end of line; with count: Delete from current line up `count` number of keys.", tip: "delete"},
     D: countSelectsLines('up', [
         "modalkeys.cancelMultipleSelections",
         { "cursorMove": { to: "wrappedLineEnd", select: true } },
@@ -808,22 +808,22 @@ keybindings: {
         { "modalkeys.enterMode": { mode: "normal" } }, // modalkeys.enterNormal has async issues that cause the entire line to be deleted here
     ]),
 
-    "::doc::x": {kind: "action", label: "delete char", detail: "delete the character under the cursor", tip: [ "text", "delete" ]},
+    "::doc::x": {kind: "action", label: "delete char", detail: "delete the character under the cursor", tip: "delete"},
     x: [
         "modalkeys.cancelMultipleSelections",
         { "cursorMove": { to: "right", select: true } },
         "editor.action.clipboardCutAction",
     ],
 
-    "::doc::,r": {kind: "action", label: "replace char", detail: "replace the character under the cursor", tip: [ "text", "change" ]},
+    "::doc::,r": {kind: "action", label: "replace char", detail: "replace the character under the cursor", tip: "change"},
     ",r": "modalkeys.replaceChar",
 
-    "::doc::y": {kind: "action", label: "copy", detail: "copy selected text to clipboard", tip: [ "text", "copy" ] },
+    "::doc::y": {kind: "action", label: "copy", detail: "copy selected text to clipboard", tip: "copy" },
     y: countSelectsLines('down', [
         "editor.action.clipboardCopyAction", "modalkeys.cancelMultipleSelections",
     ]),
 
-    "::doc::Y": {kind: "action", label: "copy (eol/up)", detail: "without a count: copy to end of line; with a count: copy this and the previous N lines", tip: [ "text", "copy" ]},
+    "::doc::Y": {kind: "action", label: "copy (eol/up)", detail: "without a count: copy to end of line; with a count: copy this and the previous N lines", tip: "copy"},
     Y: countSelectsLines('up', [
         { "cursorMove": { to: "wrappedLineEnd", select: true } },
         "editor.action.clipboardCopyAction",
@@ -833,7 +833,7 @@ keybindings: {
         "modalkeys.cancelMultipleSelections"
     ]),
 
-    "::doc::v": {kind: "action", label: "paste after", detail: "Paste the next after the cursor/selection", tip: [ "text", "copy" ]},
+    "::doc::v": {kind: "action", label: "paste after", detail: "Paste the next after the cursor/selection", tip: "copy"},
     v: [
         {
             if: "!__selection.isEmpty",
@@ -849,7 +849,7 @@ keybindings: {
         "editor.action.clipboardPasteAction",
     ],
 
-    "::doc::V": {kind: "action", label: "paste before", detail: "Paste the next before the cursor/selection", tip: [ "text", "copy" ]},
+    "::doc::V": {kind: "action", label: "paste before", detail: "Paste the next before the cursor/selection", tip: "copy"},
     V: [
         {
             if: "!__selection.isEmpty",
@@ -861,14 +861,14 @@ keybindings: {
         "editor.action.clipboardPasteAction",
     ],
 
-    "::doc::gV": {kind: "action", label: "paste replace", detail: "Paste, replacing the selected text", tip: [ "advanced_text", "copy" ]},
+    "::doc::gV": {kind: "action", label: "paste replace", detail: "Paste, replacing the selected text", tip: "advanced_copy"},
     "gV": "editor.action.clipboardPasteAction",
 
-    "::doc::gv": {kind: "action", label: "paste history", detail: "Paste from clipboard history", tip: [ "advanced_text", "copy" ]},
+    "::doc::gv": {kind: "action", label: "paste history", detail: "Paste from clipboard history", tip: "advanced_copy"},
     "gv": "clipboard-manager.editor.pickAndPaste" ,
 
 
-    "::doc::,v": {kind: "action", label: "paste after line", detail: "Paste text after current line", tip: [ "advanced_text", "copy" ]},
+    "::doc::,v": {kind: "action", label: "paste after line", detail: "Paste text after current line", tip: "advanced_copy"},
     ",v": [
         "expandLineSelection",
         "selection-utilities.activeAtEnd",
@@ -876,7 +876,7 @@ keybindings: {
         "editor.action.clipboardPasteAction",
     ],
 
-    "::doc::,V": {kind: "action", label: "paste before line", detail: "Paste text before current line", tip: [ "advanced_text", "copy" ]},
+    "::doc::,V": {kind: "action", label: "paste before line", detail: "Paste text before current line", tip: "advanced_copy"},
     ",V": [
         "expandLineSelection",
         "selection-utilities.activeAtStart",
@@ -886,31 +886,31 @@ keybindings: {
 
 
     // #### begin line below
-    "::doc::o": {kind: "mode", label: "open below", detail: "open a line below current line and enter insert", tip: [ "advanced_text", "insert" ]},
+    "::doc::o": {kind: "mode", label: "open below", detail: "open a line below current line and enter insert", tip: "advanced_insert"},
     o: ["editor.action.insertLineAfter", "modalkeys.enterInsert"],
-    "::doc::go": {kind: "action", label: "open below", detail: "open a line below current line", tip: [ "advanced_text", "insert" ]},
+    "::doc::go": {kind: "action", label: "open below", detail: "open a line below current line", tip: "advanced_insert"},
     go: "editor.action.insertLineAfter",
-    "::doc::visual::o": {kind: "mode", label: "open below", detail: "open a line below current selection and enter insert", tip: [ "advanced_text", "insert" ]},
+    "::doc::visual::o": {kind: "mode", label: "open below", detail: "open a line below current selection and enter insert", tip: "advanced_insert"},
     "visual::o": "selection-utilities.activeAtEnd",
-    "::doc::O": {kind: "mode", label: "open above", detail: "open a line above current line and enter insert", tip: [ "advanced_text", "insert" ]},
+    "::doc::O": {kind: "mode", label: "open above", detail: "open a line above current line and enter insert", tip: "advanced_insert"},
     O: [ "editor.action.insertLineBefore", "modalkeys.enterInsert" ],
-    "::doc::gO": {kind: "action", label: "open above", detail: "open a line above current line", tip: [ "advanced_text", "insert" ]},
+    "::doc::gO": {kind: "action", label: "open above", detail: "open a line above current line", tip: "advanced_insert"},
     gO: "editor.action.insertLineBefore",
-    "::doc::visual::o": {kind: "mode", label: "open before", detail: "open a line above current selection and enter insert", tip: [ "advanced_text", "insert" ]},
+    "::doc::visual::o": {kind: "mode", label: "open before", detail: "open a line above current selection and enter insert", tip: "advanced_insert"},
     "visual::O": "selection-utilities.activeAtStart",
 
     // #### line indent
-    "::doc::>": {kind: "action", label: "indent", detail: "Indent lines", tip: [ "advanced_text", "indent"]},
+    "::doc::>": {kind: "action", label: "indent", detail: "Indent lines", tip: "text_indent"},
     ">": countSelectsLines('down', "editor.action.indentLines", [
         "editor.action.indentLines", 
         "modalkeys.cancelMultipleSelections"
     ]),
-    "::doc::<": {kind: "action", label: "deindent", detail: "Deindent lines", tip: [ "advanced_text", "indent"]},
+    "::doc::<": {kind: "action", label: "deindent", detail: "Deindent lines", tip: "text_indent"},
     "<": countSelectsLines('down', "editor.action.outdentLines", [
         "editor.action.outdentLines", 
         "modalkeys.cancelMultipleSelections"
     ]),
-    "::doc::g>": {kind: "action", label: "format", detail: "Format code", tip: [ "advanced_text", "indent"]},
+    "::doc::g>": {kind: "action", label: "format", detail: "Format code", tip: "text_indent"},
     "g>": countSelectsLines('down', "editor.action.formatSelection", [
         "editor.action.formatSelection",
         "modalkeys.cancelMultipleSelections"

--- a/presets/larkin.js
+++ b/presets/larkin.js
@@ -83,16 +83,79 @@ docKinds: [
     { name: 'leader',   description: "Leaders serve as prefixes to an entire list of key commands" }
 ],
 
+// TODO: would be better if instead of `keys`, the ::doc:: section referred to
+// the various places in docTips, so if you cahnge the key you need only change
+// the doc in one place, not two (in progress)
+
+docTips: [
+    { 
+        title: "Basic Motions" ,
+        commnet: "The standard motions to move around and select text.",
+        id: "basic",
+        prefixes: [ "", "'", "u", "g" ],
+        priority: { normal: 0, visual: 10 },
+        entries: [
+            { title: "Cursor Movement", id: "cursor" },
+            { title: "Advanced Cursor Movement", id: "advanced" },
+            { title: "Word Movement", id: "word" },
+            { title: "Document Movement", id: "document" },
+            { note: "Many additional selection commands", id: "select_leader" },
+            { note: "Selects around an entire object (e.g. word)", id: 'around_tip' }
+        ]
+    },
+    { 
+        title: "Search",
+        comment: "Selection by searching specific strings",
+        key: "search",
+        prefix: [ "" ],
+        entries: [
+            { title: "By Cursor", keys: [ '*', "&" ] },
+            { title: "By Character", keys: [ 'f', 'F', 't', 'T', 's', 'S' ]},
+            { title: "By String", keys: [ '/', '?' ] },
+            { title: "Iteration", keys: [ 'n', 'N', ';', ':' ]},
+        ]
+    },
+    { 
+        title: "Advanced Motions",
+        key: "advanced",
+        comment: "Many of the most useful, more complex motions for selecting text.",
+        prefix: [ "", "'", "u" ],
+        priority: { normal: 0, visual: 10 },
+        entries: [
+            { title: "Numbers", id: "number" },
+            { title: "Comments", id: "comment" },
+            { title: "Regions", id: "region" },
+            { title: "Brackets", id: "bracket" },
+            { title: "Indent", id: "ident" },
+            { more: [ "notebook", "argument", "text" ] },
+            { note: "Many additional selection commands", id: "select_leader" },
+            { note: "Selects around an entire object (e.g. word)", key: 'u' }
+        ]
+    },
+    { 
+        title: "Function Argument Motions",
+        key: "argument",
+        prefix: [ ",", "u" ],
+        keys: [ ",w", ",b", ",W", ",B", "u.", "u,", "u>", "u<" ]
+    },
+    {
+        title: "Notebook Motions",
+        key: "notebook",
+        priority: { normal: 0, visual: 10 },
+        keys: [ "'y", "'yc", "'yC", "uy" ],
+    },
+],
+
 keybindings: {
     // ### Motions
 
     // basic movement
-    "::doc::h": { kind: "select", label: "←", detail: "move left" },
-    "::doc::j": { kind: "select", label: '↓', detail: "move down" },
-    "::doc::k": { kind: "select", label: '↑', detail: "move up" },
-    "::doc::l": { kind: "select", label: '→', detail: "move right" },
+    "::doc::h": { kind: "select", label: "←", detail: "move left", tip: [ "basic", "cursor" ]},
+    "::doc::j": { kind: "select", label: '↓', detail: "move down", tip: [ "basic", "cursor" ] },
+    "::doc::k": { kind: "select", label: '↑', detail: "move up", tip: [ "basic", "cursor" ] },
+    "::doc::l": { kind: "select", label: '→', detail: "move right", tip: [ "basic", "cursor" ] },
     "::doc::g": { kind: "leader", label: "actions (mostly)", detail: "additional commands (mostly actions)" },
-    "::doc::gj": { kind: "select", label: 'unwrp ↓', detail: "Down unwrapped line" },
+    "::doc::gj": { kind: "select", label: 'unwrp ↓', detail: "Down unwrapped line"},
     "::doc::gk": { kind: "select", label: 'unwrp ↑', detail: "Up unwrapped line"},
     "::using::cursorMove::": {
         h: { to: 'left', select: "__mode !== 'normal'", value: '__count' },
@@ -104,33 +167,33 @@ keybindings: {
     },
 
     // line related movements
-    "::doc::H": { kind: "select", label: "start", detail: "start of line (alterantes between first non-whitepace, and first)" },
+    "::doc::H": { kind: "select", label: "start", detail: "start of line (alterantes between first non-whitepace, and first)", tip: [ "basic", "advanced" ] },
     H: "cursorHomeSelect",
-    "::doc::L": { kind: "select", label: "end", detail: "end of line" },
+    "::doc::L": { kind: "select", label: "end", detail: "end of line", tip: [ "basic", "advanced" ] },
     L: { "cursorMove": { to: "wrappedLineEnd", select: true } },
-    "::doc::G": { kind: "select", label: "expand", detail: "expand selections to full lines" },
+    "::doc::G": { kind: "select", label: "expand", detail: "expand selections to full lines", tip: [ "basic", "advanced" ] },
     G:  "expandLineSelection",
-    "::doc::K": { kind: "select", label: "sel ↑", detail: "select lines upwards" },    
+    "::doc::K": { kind: "select", label: "sel ↑", detail: "select lines upwards", tip: [ "basic", "advanced" ] },    
     K: [
         "modalkeys.cancelMultipleSelections",
         { "cursorMove": { to: 'up', by: 'wrappedLine', select: true, value: '__count' } },
         "expandLineSelection",
         "selection-utilities.activeAtStart"
     ],
-    "::doc::J": { kind: "select", label: "sel ↓", detail: "select lines downwards" },    
+    "::doc::J": { kind: "select", label: "sel ↓", detail: "select lines downwards", tip: [ "basic", "advanced" ] },    
     J: [
         "modalkeys.cancelMultipleSelections",
         { "cursorMove": { to: 'down', by: 'wrappedLine', select: true, value: '__count' } },
         "expandLineSelection",
     ],
-    "::doc::gK": { kind: "select", label: 'unwrp sel ↑', detail: "select unwrapped lines upwards" },
+    "::doc::gK": { kind: "select", label: 'unwrp sel ↑', detail: "select unwrapped lines upwards", tip: [ "basic", "advanced" ] },
     gK: [
         "modalkeys.cancelMultipleSelections",
         { "cursorMove": { to: 'up', by: 'line', select: true, value: '__count' } },
         "expandLineSelection",
         "selection-utilities.activeAtStart"
     ],
-    "::doc::gJ": { kind: "select", label: 'unwrp sel ↓', detail: "select unwrapped lines downwards" },
+    "::doc::gJ": { kind: "select", label: 'unwrp sel ↓', detail: "select unwrapped lines downwards", tip: [ "basic", "advanced" ] },
     gJ: [
         "modalkeys.cancelMultipleSelections",
         { "cursorMove": { to: 'down', by: 'line', select: true, value: '__count' } },
@@ -138,54 +201,54 @@ keybindings: {
     ],
 
 
-    "::doc::\\": { kind: "select", label: 'right character', detail: "select *just* the character to the right" },
+    "::doc::\\": { kind: "select", label: 'right character', detail: "select *just* the character to the right", tip: [ "basic", "advanced" ] },
     "\\": [
         "modalkeys.cancelMultipleSelections",
         { "cursorMove": { to: 'right', select: true, value: '__count' } }
     ],
-    "::doc::|": { kind: "select", label: 'left character', detail: "select *just* the character to the left" },
+    "::doc::|": { kind: "select", label: 'left character', detail: "select *just* the character to the left", tip: [ "basic", "advanced" ] },
     "|": [
         "modalkeys.cancelMultipleSelections",
         { "cursorMove": { to: 'left', select: true, value: '__count' } }
     ],
 
     // movements around regex units
-    "::doc::'": { kind: "leader", label: "select (mostly)", detail: "additional commands (mostly selection/view related)"},
-    "::doc::u": { kind: "leader", label: "around", detail: "selection commands that move start and end of a selection to surround the entire object (rather than extending to specified start/end point)" },
+    "::doc::'": { kind: "leader", label: "select (mostly)", detail: "additional commands (mostly selection/view related)", tip: [ "select_leader" ]},
+    "::doc::u": { kind: "leader", label: "around", detail: "selection commands that move start and end of a selection to surround the entire object (rather than extending to specified start/end point)", tip: [ "around_tip" ] },
     "::doc::u'": { kind: "leader", label: "select", detail: "additional selections"},
-    "::doc::w": { kind: "select", label: "subwrd →", detail: "next subword (camel/snake case)" },
-    "::doc::W": { kind: "select", label: "word →", detail: "next word"},
-    "::doc::e": { kind: "select", label: "word end →", detail: "next word end" },
-    "::doc::b": { kind: "select", label: "subwrd ←", detail: "previous subword (came/snake case)" },
-    "::doc::B": { kind: "select", label: "word ←", detail: "previous word" },
-    "::doc::E": { kind: "select", label: "word end ←", detail: "previous word end" },
+    "::doc::w": { kind: "select", label: "subwrd →", detail: "next subword (camel/snake case)", tip: [ "basic", "word" ] },
+    "::doc::W": { kind: "select", label: "word →", detail: "next word", tip: [ "basic", "word" ]},
+    "::doc::e": { kind: "select", label: "word end →", detail: "next word end", tip: [ "basic", "word" ] },
+    "::doc::b": { kind: "select", label: "subwrd ←", detail: "previous subword (came/snake case)", tip: [ "basic", "word" ] },
+    "::doc::B": { kind: "select", label: "word ←", detail: "previous word", tip: [ "basic", "word" ] },
+    "::doc::E": { kind: "select", label: "word end ←", detail: "previous word end", tip: [ "basic", "word" ] },
     "::doc::uw": { kind: "select", label: "subwrd →", detail: "select entire subword with and trailing whitespace (camel/snake case)" },
     "::doc::uW": { kind: "select", label: "word →", detail: "select entire word and trailing whitespace"},
     "::doc::ue": { kind: "select", label: "in word →", detail: "select entire word (no whitespace)" },
     "::doc::ub": { kind: "select", label: "subwrd ←", detail: "select previous subword and trailing whitespace (came/snake case)" },
     "::doc::uB": { kind: "select", label: "word ←", detail: "select previous word and trailing whitespace" },
     "::doc::uE": { kind: "select", label: "in word ←", detail: "select previous word (no whitespace)" },    
-    "::doc::@": { kind: "select", label: "number ←", detail: "next number" },
-    "::doc::#": { kind: "select", label: "number →", detail: "previous number" },
-    "::doc::';": { kind: "select", label: "comment →", detail: "next commented region" },
-    "::doc::':": { kind: "select", label: "comment ←", detail: "previous commented region" },
-    "::doc::,;": { kind: "select", label: "blk commt →", detail: "next block commented region" },
-    "::doc::,:": { kind: "select", label: "blk commt ←", detail: "previous block commented region" },
-    "::doc::p": { kind: "select", label: "pargrph →", detail: "next pagaraph" },
-    "::doc::P": { kind: "select", label: "pargrph ←", detail: "previous paragraph" },
-    "::doc::')": { kind: "select", label: "sec →", detail: "next section" },
-    "::doc::'(": { kind: "select", label: "sec ←", detail: "previous section" },
-    "::doc::)": { kind: "select", label: "subsec →", detail: "next subsection" },
-    "::doc::(": { kind: "select", label: "subsec ←", detail: "previous subsection" },
+    "::doc::@": { kind: "select", label: "number ←", detail: "next number", tip: [ "advanced", "number" ] },
+    "::doc::#": { kind: "select", label: "number →", detail: "previous number", tip: [ "advanced", "number" ] },
+    "::doc::';": { kind: "select", label: "comment →", detail: "next commented region" , tip: [ "advanced", "comment" ]},
+    "::doc::':": { kind: "select", label: "comment ←", detail: "previous commented region" , tip: [ "advanced", "comment" ]},
+    "::doc::,;": { kind: "select", label: "blk commt →", detail: "next block commented region" , tip: [ "advanced", "comment" ]},
+    "::doc::,:": { kind: "select", label: "blk commt ←", detail: "previous block commented region" , tip: [ "advanced", "comment" ]},
+    "::doc::p": { kind: "select", label: "pargrph →", detail: "next pagaraph", tip: [ "advanced", "region" ] },
+    "::doc::P": { kind: "select", label: "pargrph ←", detail: "previous paragraph", tip: [ "advanced", "region" ] },
+    "::doc::')": { kind: "select", label: "sec →", detail: "next section", tip: [ "advanced", "region" ] },
+    "::doc::'(": { kind: "select", label: "sec ←", detail: "previous section", tip: [ "advanced", "region" ] },
+    "::doc::)": { kind: "select", label: "subsec →", detail: "next subsection", tip: [ "advanced", "region" ] },
+    "::doc::(": { kind: "select", label: "subsec ←", detail: "previous subsection", tip: [ "advanced", "region" ] },
     "::doc::up": { kind: "select", label: "pargrph →", detail: "next pagaraph" },
     "::doc::uP": { kind: "select", label: "pargrph ←", detail: "previous paragraph" },
     "::doc::u')": { kind: "select", label: "sec →", detail: "next section" },
     "::doc::u'(": { kind: "select", label: "sec ←", detail: "previous section" },
     "::doc::u)": { kind: "select", label: "subsec →", detail: "next subsection" },
     "::doc::u(": { kind: "select", label: "subsec ←", detail: "previous subsection" },
-    "::doc::'w": { kind: "select", label: "WORD →", detail: "next WORD; e.g. contiguous non-whitespace region"},
-    "::doc::'b": { kind: "select", label: "WORD ←", detail: "previous WORD; e.g. contiguous non-whitespace region"},
-    "::doc::'e": { kind: "select", label: "WORD end →", detail: "to end of WORD; e.g. contiguous non-whitespace region"},
+    "::doc::'w": { kind: "select", label: "WORD →", detail: "next WORD; e.g. contiguous non-whitespace region", tip: [ "basic", "word" ]},
+    "::doc::'b": { kind: "select", label: "WORD ←", detail: "previous WORD; e.g. contiguous non-whitespace region", tip: [ "basic", "word" ]},
+    "::doc::'e": { kind: "select", label: "WORD end →", detail: "to end of WORD; e.g. contiguous non-whitespace region", tip: [ "basic", "word" ]},
     "::doc::u'w": { kind: "select", label: "WORD →", detail: "select entire WORD and trailing whitespace; a WORD is a contiguous non-whitespace region" },
     "::doc::u'e": { kind: "select", label: "WORD →", detail: "select entire WORD; a WORD is a contiguous non-whitespace region" },
 
@@ -266,15 +329,15 @@ keybindings: {
     },
 
     // generic, magic selection
-    "::doc::uu": { kind: 'select', label: "smart expand", detail: "Use VSCode's built-in smart expansion command"},
+    "::doc::uu": { kind: 'select', label: "smart expand", detail: "Use VSCode's built-in smart expansion command", tip: [ "advanced", "region" ]},
     "uu": "editor.action.smartSelect.expand",
 
     // buffer related
-    "::doc::$": { kind: "select", label: "all", detail: "Select the entire document" },
+    "::doc::$": { kind: "select", label: "all", detail: "Select the entire document", tip: [ "basic", "document" ] },
     $: [ "editor.action.selectAll" ],
-    "::doc::gG": { kind: 'select', label: 'doc end'},
+    "::doc::gG": { kind: 'select', label: 'doc end', tip: [ "basic", "document" ] },
     "gG": "cursorBottomSelect",
-    "::doc::gg": { kind: 'select', label: 'doc start'},
+    "::doc::gg": { kind: 'select', label: 'doc start', tip: [ "basic", "document" ] },
     "gg": "cursorTopSelect",
 
     // search related
@@ -377,14 +440,14 @@ keybindings: {
 
     // ### more complex syntactic selections
 
-    "::doc::%": { kind: 'select', label: 'to bracket', detail: "Move to matching bracket"},
+    "::doc::%": { kind: 'select', label: 'to bracket', detail: "Move to matching bracket", tip: [ "advanced", "bracket" ]},
     '%': "editor.action.jumpToBracket",
-    "::doc::''": {kind: 'select', label: 'in quotes', detail: "text within current quotes"},
+    "::doc::''": {kind: 'select', label: 'in quotes', detail: "text within current quotes", tip: [ "advanced", "bracket" ]},
     "''": "bracketeer.selectQuotesContent",
-    "::doc::'\"": {kind: 'select', label: 'around quotes', detail: "quotes and text within current quotes"},
+    "::doc::'\"": {kind: 'select', label: 'around quotes', detail: "quotes and text within current quotes", tip: [ "advanced", "bracket" ]},
     "'\"": ["bracketeer.selectQuotesContent", "bracketeer.selectQuotesContent"],
     // the below is a bit hacky; I want to add these commandsto my extension
-    "::doc::[": {kind: 'select', label: 'in parens', detail: 'text inside parents/brackets/braces'},
+    "::doc::[": {kind: 'select', label: 'in parens', detail: 'text inside parents/brackets/braces', tip: [ "advanced", "bracket" ]},
     "[": [
         {
             if: "!__selection.isEmpty",
@@ -397,7 +460,7 @@ keybindings: {
         },
         { "editor.action.selectToBracket": {"selectBrackets": false} }
     ],
-    "::doc::{": {kind: 'select', label: 'arnd parens', detail: 'parents/brackets/braces and their contents'},
+    "::doc::{": {kind: 'select', label: 'arnd parens', detail: 'parents/brackets/braces and their contents', tip: [ "advanced", "bracket" ]},
     "{": [
         {
             if: "!__selection.isEmpty",
@@ -411,18 +474,19 @@ keybindings: {
         { "editor.action.selectToBracket": {"selectBrackets": true} }
     ],
 
-    "::doc::'>": { kind: 'select', label: 'in <>', detail: 'text inside angle brackets'},
+    "::doc::'>": { kind: 'select', label: 'in <>', detail: 'text inside angle brackets', tip: [ "advanced", "bracket" ]},
     "'>": "extension.selectAngleBrackets",
-    "::doc::'<": { kind: 'select', label: 'in ><', detail: 'text inside tag pairs (e.g. <a>text</a>)'},
+    "::doc::'<": { kind: 'select', label: 'in ><', detail: 'text inside tag pairs (e.g. <a>text</a>)', tip: [ "advanced", "bracket" ]},
     "'<": "extension.selectInTag",
 
-    "::doc::']": {kind: 'select', label: 'indent+top', detail: 'all text at same indent and the unindent line just above it (ala python syntax)'},
+    "::doc::']": {kind: 'select', label: 'indent+top', detail: 'all text at same indent and the unindent line just above it (ala python syntax)', tip: [ "advanced", "ident" ]},
     "']": "vscode-select-by-indent.select-outer-top-only",
-    "::doc::]": {kind: 'select', label: 'inside indent', detail: 'all text at same indent'},
+    "::doc::]": {kind: 'select', label: 'inside indent', detail: 'all text at same indent', tip: [ "advanced", "ident" ]},
     "]": "vscode-select-by-indent.select-inner",
-    "::doc::}": {kind: 'select', label: 'around indent', detail: 'all text at same indent along with the line above and below this (ala c-like synatx)'},
+    "::doc::}": {kind: 'select', label: 'around indent', detail: 'all text at same indent along with the line above and below this (ala c-like synatx)', tip: [ "advanced", "ident" ]},
     "}": "vscode-select-by-indent.select-outer",
 
+    // TODO: this is where I stopped adding commands to `docTips`
     "::doc::u`": {kind: 'select', label: 'inside ``', detail: 'inside first character pair `` (non syntactical, useful inside comments)'},
     "u`": { "modalkeys.selectBetween": {
         from: "`", to: "`",

--- a/presets/larkin.js
+++ b/presets/larkin.js
@@ -205,7 +205,7 @@ keybindings: {
         E:     { unit: "word",    boundary: "end",   select:      true, value: '-(__count || 1)' },
         "'w":  { unit: "WORD",    boundary: "start", select:      true, value: " (__count || 1)" },
         "'b":  { unit: "WORD",    boundary: "start", select:      true, value: "-(__count || 1)" },
-        "'e":  { unit: "WORD",    boundary: "end",   select:      true, value: "-(__count || 1)" },
+        "'e":  { unit: "WORD",    boundary: "end",   select:      true, value: " (__count || 1)" },
         "u'w": { unit: "WORD",    boundary: "start", selectWhole: true, value: " (__count || 1)" },
         "u'e": { unit: "WORD",    boundary: "both",  selectWhole: true, value: " (__count || 1)" },
         "u'b": { unit: "WORD",    boundary: "start", selectWhole: true, value: "-(__count || 1)" },
@@ -236,13 +236,38 @@ keybindings: {
     },
 
     // jupyter based cell selection
-    "::doc::'y": { kind: "select", label: "jupyter", detail: "jupyter related selection commands"},
-    "::doc::'yc": { kind: "select", label: "cell →", detail: "next jupyter notebook cell"},
-    "'yc": ["jupyter.gotoNextCellInFile", "jupyter.selectCell"],
-    "::doc::'yC": { kind: "select", label: "cell ←", detail: "previous jupyter notebook cell"},
-    "'yC": ["jupyter.gotoPrevCellInFile", "jupyter.selectCell"],
+    "::doc::'y": { kind: "select", label: "cell →", detail: "next jupyter notebook cell"},
+    "'y": {
+        if: "__language == 'markdown' || __language == 'quarto'",
+        then: "terminal-polyglot.next-fence-select",
+        else: [
+            { "jupyter.gotoNextCellInFile": {}, repeat: "__count" },
+            { "revealLine": { lineNumber: '__line', at: 'center' } },
+            "jupyter.selectCell"
+        ],
+    },
+    "::doc::'Y": { kind: "select", label: "cell ←", detail: "previous jupyter notebook cell"},
+    "'Y": {
+        if: "__language == 'markdown' || __language == 'quarto'",
+        then: "terminal-polyglot.prev-fence-select",
+        else: [
+            { "jupyter.gotoPrevCellInFile": {}, repeat: "__count" }, 
+            { "revealLine": { lineNumber: '__line', at: 'center' } },
+            "jupyter.selectCell"
+        ],
+    },
     "::doc::uy": { kind: "select", label: "cell", detail: "select a jyputer notebook cell"},
-    uy: "jupyter.selectCell",
+    uy: {
+        if: "__language == 'markdown' || __language == 'quarto'",
+        then: "terminal-polyglot.select-fence",
+        else: "jupyter.selectCell",
+    },
+    "::doc::,y": { kind: "action", label: "create cell", detail: "Create a new jupyter notebook cell"},
+    ",y": {
+        if: "__language == 'quarto'",
+        then: "quarto.insertCodeCell",
+        else: "jupyter.selectCell",
+    },
 
     // function arguments
     "::doc::,": { kind: "leader", label: "window (mostly)", detail: "additional commands, mostly related to changes to the editor/view/window" },
@@ -445,8 +470,7 @@ keybindings: {
         docScope: true
     }},
 
-    "::doc::u[": {kind: 'select', label: 'around []', detail: 'around first character pair `[]` (non syntactical, useful inside comments)'},    
-    "u]": { "modalkeys.selectBetween": {
+    "::doc::u[": {kind: 'select', label: 'around []', detail: 'around first character pair `[]` (non syntactical, useful inside comments)'},    "u]": { "modalkeys.selectBetween": {
         from: "[", to: "]",
         inclusive: true,
         caseSensitive: true,
@@ -472,6 +496,34 @@ keybindings: {
     "::doc::uC)": {kind: 'select', label: 'around ()', detail: 'around first pair of `()` (non syntactical, useful inside comments)' },  
     "uC)": { "modalkeys.selectBetween": {
         from: "(", to: ")",
+        inclusive: false,
+        caseSensitive: true,
+        docScope: true
+    }},
+    "::doc::uC[": {kind: 'select', label: 'inside []', detail: 'inside first pair of `[]` (non syntactical, useful inside comments)' },  
+    "uC[": { "modalkeys.selectBetween": {
+        from: "[", to: "]",
+        inclusive: false,
+        caseSensitive: true,
+        docScope: true
+    }},
+    "::doc::uC]": {kind: 'select', label: 'around []', detail: 'around first pair of `[]` (non syntactical, useful inside comments)' },  
+    "uC]": { "modalkeys.selectBetween": {
+        from: "[", to: "]",
+        inclusive: false,
+        caseSensitive: true,
+        docScope: true
+    }},
+    "::doc::uC{": {kind: 'select', label: 'inside {}', detail: 'inside first pair of `{}` (non syntactical, useful inside comments)' },  
+    "uC{": { "modalkeys.selectBetween": {
+        from: "{", to: "}",
+        inclusive: false,
+        caseSensitive: true,
+        docScope: true
+    }},
+    "::doc::uC}": {kind: 'select', label: 'around {}', detail: 'around first pair of `{}` (non syntactical, useful inside comments)' },  
+    "uC}": { "modalkeys.selectBetween": {
+        from: "{", to: "}",
         inclusive: false,
         caseSensitive: true,
         docScope: true
@@ -511,6 +563,54 @@ keybindings: {
         executeAfter: { "modalkeys.selectBetween": {
             from: "__captured",
             to: "__captured",
+            inclusive: false,
+            caseSensitive: true,
+            docScope: true
+        }},
+    }},
+
+    "::doc::uz": {kind: 'select', label: 'in 2char pair ex.', detail: 'between two sets of characters pairs (four total chars), exclusive of the pair; for example, select bob in the string [{bob}] by typing uz[{}]'},
+    uz: { "modalkeys.captureChar": {
+        acceptAfter: 4,
+        executeAfter: { "modalkeys.selectBetween": {
+            from: "__captured.slice(0,2)",
+            to: "__captured.slice(2,4)",
+            inclusive: false,
+            caseSensitive: true,
+            docScope: true
+        }},
+    }},
+
+    "::doc::uZ": {kind: 'select', label: 'in 2char pair in.', detail: 'between two sets of characters pairs (four total chars), inclusive of the pair; for example, select the string [{bob}] by typing uz[{}]'},
+    uZ: { "modalkeys.captureChar": {
+        acceptAfter: 4,
+        executeAfter: { "modalkeys.selectBetween": {
+            from: "__captured.slice(0,2)",
+            to: "__captured.slice(2,4)",
+            inclusive: true,
+            caseSensitive: true,
+            docScope: true
+        }},
+    }},
+
+    "::doc::ux": {kind: 'select', label: 'btwn chars ex.', detail: 'between two distinct characters, exclusive of the pair'},
+    ux: { "modalkeys.captureChar": {
+        acceptAfter: 2,
+        executeAfter: { "modalkeys.selectBetween": {
+            from: "__captured[0]",
+            to: "__captured[1]",
+            inclusive: false,
+            caseSensitive: true,
+            docScope: true
+        }},
+    }},
+
+    "::doc::uX": {kind: 'select', label: 'btwn chars inc.', detail: 'between two distinct characters, inclusive of the pair'},
+    uX: { "modalkeys.captureChar": {
+        acceptAfter: 2,
+        executeAfter: { "modalkeys.selectBetween": {
+            from: "__captured[0]",
+            to: "__captured[1]",
             inclusive: false,
             caseSensitive: true,
             docScope: true
@@ -853,6 +953,14 @@ keybindings: {
     "-": "cursorUndo",
     "::doc::_": {kind: "history", label: "cursor redo", detail: "VSCode Cursor Redo"},
     "_": "cursorRedo",
+    "::doc::g-": {kind: "history", label: "nav ←", detail: "Go back in navigation history (e.g. goto definition)"},
+    "g-": "workbench.action.navigateBackInNavigationLocations",
+    "::doc::g_": {kind: "history", label: "nav →", detail: "Go forward in navigation history (e.g. goto definition)"},
+    "g_": "workbench.action.navigateForwardInNavigationLocations",
+    "::doc::'-": {kind: "history", label: "edit hist ←", detail: "Go back in edit history (e.g. goto definition)"},
+    "'-": "workbench.action.navigateBackInEditLocations",
+    "::doc::'_": {kind: "history", label: "edit hist →", detail: "Go forward in edit history (e.g. goto definition)"},
+    "'_": "workbench.action.navigateForwardInEditLocations",
 
     "::doc::.": {kind: "history", label: "repeat", detail: "repeat last sentence (last selection and action pair)"},
     ".": [
@@ -884,8 +992,8 @@ keybindings: {
     "gq": "rewrap.rewrapComment",
 
     // ### terminal actions
-    "::doc::m": {kind: "action", label: "to repl", detail: "send text to a terminal (usually containing a REPL); use langauge specific extensions when available and put the pasted code into a block (when defined)."},
-    m: countSelectsLines('down', [
+    "::doc::M": {kind: "action", label: "to repl", detail: "send text to a terminal (usually containing a REPL); use langauge specific extensions when available and put the pasted code into a block (when defined)."},
+    M: countSelectsLines('down', [
         {
             if: "__language == 'julia'",
             then: {
@@ -902,8 +1010,8 @@ keybindings: {
         "modalkeys.cancelMultipleSelections",
         "modalkeys.touchDocument"
     ]),
-    "::doc::M": {kind: "action", label: "to repl (v2)", detail: "send text to a terminal (usually containing a REPL), placing in a block when defined."},
-    M: countSelectsLines('down', [
+    "::doc::m": {kind: "action", label: "to repl (v2)", detail: "send text to a terminal (usually containing a REPL), placing in a block when defined."},
+    m: countSelectsLines('down', [
         {
             if: "!__selection.isSingleLine",
             then: "terminal-polyglot.send-block-text",
@@ -934,18 +1042,30 @@ keybindings: {
     gc: "merge-conflict.next",
     "::doc::gC": {kind: "action", label: "← conflict", detail: "move to previous merge conflict"},
     gC: "merge-conflict.previous",
-    "::doc::g[": {kind: "action", label: "current", detail: "accept current change"},
+    "::doc::g[": {kind: "action", label: "acpt current", detail: "accept current change"},
     "g[": "merge-conflict.accept.current",
-    "::doc::g]": {kind: "action", label: "incoming", detail: "accept incoming change"},
+    "::doc::g]": {kind: "action", label: "acpt incoming", detail: "accept incoming change"},
     "g]": "merge-conflict.accept.incoming",
-    "::doc::g\\": {kind: "action", label: "both", detail: "accept both changes"},
+    "::doc::g\\": {kind: "action", label: "acpt both", detail: "accept both changes"},
     "g\\": "merge-conflict.accept.both",
     "::doc::g{": {kind: "action", label: "all current", detail: "accept all current changes"},
     "g{": "merge-conflict.accept.all-current",
     "::doc::g}": {kind: "action", label: "all incoming", detail: "accept all incoming changes"},
-    "g}": "merge-conflict.accept.all-current",
+    "g}": "merge-conflict.accept.all-incoming",
     "::doc::g|": {kind: "action", label: "all both", detail: "accept all both changes"},
     "g|": "merge-conflict.accept.all-both",
+    "::doc::,p": {kind: "action", label: "→ conflict", detail: "move to next merge conflict (merge editor)"},
+    ",p": "merge.goToNextConflict",
+    "::doc::,P": {kind: "action", label: "← conflict", detail: "move to previous merge conflict (merge editor)"},
+    ",P": "merge.goToPreviousConflict",
+    "::doc::,[": {kind: "action", label: "acpt current", detail: "accept current change (merge editor)"},
+    ",[": "merge.toggleActiveConflictInput1",
+    "::doc::,{": {kind: "action", label: "cmpr current", detail: "compare current change (merge editor)"},
+    ",{": "mergeEditor.compareInput1WithBase",
+    "::doc::,]": {kind: "action", label: "acpt current", detail: "accept current change (merge editor)"},
+    ",]": "merge.toggleActiveConflictInput2",
+    "::doc::,}": {kind: "action", label: "cmpr current", detail: "compare current change (merge editor)"},
+    ",}": "mergeEditor.compareInput2WithBase",
     "::doc::,e": {kind: "select", label: "error →", detail: "move to next error"},
     ",e": "editor.action.marker.next",
     "::doc::,E": {kind: "select", label: "error ←", detail: "move to previous error"},
@@ -1108,8 +1228,8 @@ keybindings: {
         "editor.action.selectHighlights",
         { "modalkeys.enterMode": { mode: "selectedit" } },
     ],
-    "::doc::'-": { kind: "modifier", label: "restore sel", detail: "restore the most recently cleared selection"},
-    "'-": [
+    "::doc::,-": { kind: "modifier", label: "restore sel", detail: "restore the most recently cleared selection"},
+    ",-": [
         { "selection-utilities.restoreAndClear": {register: "cancel"} },
         { if: "__selections.length > 1", then: { "modalkeys.enterMode": { mode: "selectedit" }}}
     ],

--- a/presets/larkin.js
+++ b/presets/larkin.js
@@ -83,10 +83,6 @@ docKinds: [
     { name: 'leader',   description: "Leaders serve as prefixes to an entire list of key commands" }
 ],
 
-// TODO: would be better if instead of `keys`, the ::doc:: section referred to
-// the various places in docTips, so if you cahnge the key you need only change
-// the doc in one place, not two (in progress)
-
 docTips: [
     { 
         title: "Basic Motions" ,

--- a/presets/larkin.js
+++ b/presets/larkin.js
@@ -90,13 +90,12 @@ docKinds: [
 docTips: [
     { 
         title: "Basic Motions" ,
-        commnet: "The standard motions to move around and select text.",
+        comment: "The standard motions to move around and select text.",
         id: "basic",
-        prefixes: [ "", "'", "u", "g" ],
-        priority: { normal: 0, visual: 10 },
+        more: [ "advanced", "argument" ],
         entries: [
-            { title: "Cursor Movement", id: "cursor" },
-            { title: "Advanced Cursor Movement", id: "advanced" },
+            { title: "Basic Cursor Movement", id: "cursor" },
+            { title: "Cursor Movement", id: "advanced" },
             { title: "Word Movement", id: "word" },
             { title: "Document Movement", id: "document" },
             { note: "Many additional selection commands", id: "select_leader" },
@@ -104,46 +103,66 @@ docTips: [
         ]
     },
     { 
-        title: "Search",
-        comment: "Selection by searching specific strings",
-        key: "search",
-        prefix: [ "" ],
+        title: "Modifying Text",
+        comment: "The most common commands used to manipulate text",
+        id: "text",
+        more: [ "advanced_text", ],
         entries: [
-            { title: "By Cursor", keys: [ '*', "&" ] },
-            { title: "By Character", keys: [ 'f', 'F', 't', 'T', 's', 'S' ]},
-            { title: "By String", keys: [ '/', '?' ] },
-            { title: "Iteration", keys: [ 'n', 'N', ';', ':' ]},
+            { title: "Insert", id: "insert" },
+            { title: "Change", id: "change" },
+            { title: "Cut/Delete", id: "delete" },
+            { title: "Copy/Paste", id: "copy" },
+            { note: "Many additional selection commands", id: 'action_leader' },
+        ]
+    },
+    { 
+        title: "Search Motions",
+        comment: "Selection by searching specific strings",
+        id: "search",
+        entries: [
+            { title: "By Cursor", id: "cursor" },
+            { title: "By Character", id: "character" },
+            { title: "By String", id: "string" },
+            { title: "Iteration", id: "iteration" },
         ]
     },
     { 
         title: "Advanced Motions",
-        key: "advanced",
+        id: "advanced",
         comment: "Many of the most useful, more complex motions for selecting text.",
-        prefix: [ "", "'", "u" ],
-        priority: { normal: 0, visual: 10 },
+        modes: [ "normal" ],
+        more: [ "notebook", "argument", "select_text" ],
         entries: [
             { title: "Numbers", id: "number" },
             { title: "Comments", id: "comment" },
             { title: "Regions", id: "region" },
             { title: "Brackets", id: "bracket" },
             { title: "Indent", id: "ident" },
-            { more: [ "notebook", "argument", "text" ] },
-            { note: "Many additional selection commands", id: "select_leader" },
-            { note: "Selects around an entire object (e.g. word)", key: 'u' }
+            { note: "Selects around an entire object (e.g. word)", id: 'around_tip' }
+        ]
+    },
+    { 
+        title: "Advanced text modification",
+        comment: "Many of hte most useful, more complex text manipulation commands", 
+        id: "advanced_text",
+        entries: [
+            { title: "Insert", id: "insert" },
+            { title: "Copy/Paste", id: "copy" },
+            { title: "Change brackets", id: "brackets" },
+            { title: "Change captilization", id: "case" },
+            { title: "Change a number", id: "number" },
+            { title: "Indent Lines", id: "indent" }
         ]
     },
     { 
         title: "Function Argument Motions",
-        key: "argument",
-        prefix: [ ",", "u" ],
-        keys: [ ",w", ",b", ",W", ",B", "u.", "u,", "u>", "u<" ]
+        id: "argument",
     },
     {
         title: "Notebook Motions",
-        key: "notebook",
-        priority: { normal: 0, visual: 10 },
-        keys: [ "'y", "'yc", "'yC", "uy" ],
+        id: "notebook",
     },
+
 ],
 
 keybindings: {
@@ -154,7 +173,7 @@ keybindings: {
     "::doc::j": { kind: "select", label: '↓', detail: "move down", tip: [ "basic", "cursor" ] },
     "::doc::k": { kind: "select", label: '↑', detail: "move up", tip: [ "basic", "cursor" ] },
     "::doc::l": { kind: "select", label: '→', detail: "move right", tip: [ "basic", "cursor" ] },
-    "::doc::g": { kind: "leader", label: "actions (mostly)", detail: "additional commands (mostly actions)" },
+    "::doc::g": { kind: "leader", label: "actions (mostly)", detail: "additional commands (mostly actions)", tip: "action_leader" },
     "::doc::gj": { kind: "select", label: 'unwrp ↓', detail: "Down unwrapped line"},
     "::doc::gk": { kind: "select", label: 'unwrp ↑', detail: "Up unwrapped line"},
     "::using::cursorMove::": {
@@ -299,32 +318,32 @@ keybindings: {
     },
 
     // jupyter based cell selection
-    "::doc::'y": { kind: "select", label: "jupyter", detail: "jupyter related selection commands"},
-    "::doc::'yc": { kind: "select", label: "cell →", detail: "next jupyter notebook cell"},
+    "::doc::'y": { kind: "select", label: "jupyter", detail: "jupyter related selection commands", tip: [ "notebook" ]},
+    "::doc::'yc": { kind: "select", label: "cell →", detail: "next jupyter notebook cell", tip: [ "notebook" ]},
     "'yc": ["jupyter.gotoNextCellInFile", "jupyter.selectCell"],
-    "::doc::'yC": { kind: "select", label: "cell ←", detail: "previous jupyter notebook cell"},
+    "::doc::'yC": { kind: "select", label: "cell ←", detail: "previous jupyter notebook cell", tip: [ "notebook" ]},
     "'yC": ["jupyter.gotoPrevCellInFile", "jupyter.selectCell"],
-    "::doc::uy": { kind: "select", label: "cell", detail: "select a jyputer notebook cell"},
+    "::doc::uy": { kind: "select", label: "cell", detail: "select a jyputer notebook cell", tip: [ "notebook" ]},
     uy: "jupyter.selectCell",
 
     // function arguments
     "::doc::,": { kind: "leader", label: "window (mostly)", detail: "additional commands, mostly related to changes to the editor/view/window" },
     "::using::move-cursor-by-argument.move-by-argument": {
-        "::doc::,w": { kind: "select", label: "arg →", detail: "Next function argument"},
+        "::doc::,w": { kind: "select", label: "arg →", detail: "Next function argument", tip: [ "argument" ]},
         ",w":  { value: "(__count || 1)",  boundary: "end", select:      true },
-        "::doc::,b": { kind: "select", label: "arg ←", detail: "Previous function argument"},
+        "::doc::,b": { kind: "select", label: "arg ←", detail: "Previous function argument", tip: [ "argument" ]},
         ",b":  { value: "-(__count || 1)", boundary: "start", select:      true },
-        "::doc::,W": { kind: "select", label: "arg(+,) →", detail: "Next function argument (and comma)"},
+        "::doc::,W": { kind: "select", label: "arg(+,) →", detail: "Next function argument (and comma)", tip: [ "argument" ]},
         ",W":  { value: "(__count || 1)",  boundary: "start", select:      true },
-        "::doc::,B": { kind: "select", label: "arg(+,) ←", detail: "Previous function argument (and comma)"},
+        "::doc::,B": { kind: "select", label: "arg(+,) ←", detail: "Previous function argument (and comma)", tip: [ "argument" ]},
         ",B":  { value: "-(__count || 1)", boundary: "end",   select:      true },
-        "::doc::u.": { kind: 'select', label: "arg →", detail: "Around next argument"},
+        "::doc::u.": { kind: 'select', label: "arg →", detail: "Around next argument", tip: [ "argument" ]},
         "u.": { value: "(__count || 1)",  boundary: "both", selectWhole: true },
-        "::doc::u,": { kind: 'select', label: "arg ←", detail: "Around previous argument"},
+        "::doc::u,": { kind: 'select', label: "arg ←", detail: "Around previous argument", tip: [ "argument" ]},
         "u,": { value: "-(__count || 1)", boundary: "both", selectWhole: true },
-        "::doc::u>": { kind: 'select', label: "arg →", detail: "Around next argument (with comma)"},
+        "::doc::u>": { kind: 'select', label: "arg →", detail: "Around next argument (with comma)", tip: [ "argument" ]},
         "u>": { value: "(__count || 1)",  boundary: "start", selectWhole: true },
-        "::doc::u<": { kind: 'select', label: "arg ←", detail: "Around previous argument (with comma)"},
+        "::doc::u<": { kind: 'select', label: "arg ←", detail: "Around previous argument (with comma)", tip: [ "argument" ]},
         "u<": { value: "-(__count || 1)", boundary: "end",   selectWhole: true },
     },
 
@@ -341,7 +360,7 @@ keybindings: {
     "gg": "cursorTopSelect",
 
     // search related
-    "::doc::*": { kind: "select", label: "match →", detail: "Next match to object under cursor"},
+    "::doc::*": { kind: "select", label: "match →", detail: "Next match to object under cursor", tip: [ "search", "cursor" ]},
     "*": [
         { "modalkeys.search": {
             text: "__wordstr",
@@ -349,7 +368,7 @@ keybindings: {
             register: "search"
         }}
     ],
-    "::doc::&": { kind: "select", label: "match ←", detail: "Previous match to object under cursor"},
+    "::doc::&": { kind: "select", label: "match ←", detail: "Previous match to object under cursor", tip: [ "search", "cursor" ]},
     "&": [
         { "modalkeys.search": {
             text: "__wordstr",
@@ -359,12 +378,12 @@ keybindings: {
         }}
     ],
 
-    "::doc::n": { kind: "select", label: "search →", detail: "Next match to search term"},
+    "::doc::n": { kind: "select", label: "search →", detail: "Next match to search term", tip: [ "search", "iteration" ]},
     "n": { "modalkeys.nextMatch": {register: "search"}, repeat: "__count" },
-    "::doc::N": { kind: "select", label: "search →", detail: "Previous match to search term"},
+    "::doc::N": { kind: "select", label: "search →", detail: "Previous match to search term", tip: [ "search", "iteration" ]},
     "N": { "modalkeys.previousMatch": {register: "search"}, repeat: "__count" },
 
-    "::doc::/": { kind: "select", label: "search", detail: "Search forwards" },
+    "::doc::/": { kind: "select", label: "search", detail: "Search forwards", tip: [ "search", "string" ]},
     "/": { "modalkeys.search": {
         register: "search",
         caseSensitive: true,
@@ -372,7 +391,7 @@ keybindings: {
         selectTillMatch: true,
         wrapAround: true
     } },
-    "::doc::?": { kind: "select", label: "search back", detail: "Search backward" },
+    "::doc::?": { kind: "select", label: "search back", detail: "Search backward", tip: [ "search", "string" ]},
     "?": { "modalkeys.search": {
         register: "search",
         caseSensitive: true,
@@ -381,7 +400,7 @@ keybindings: {
         wrapAround: true
     } },
 
-    "::doc::f": { kind: "select", label: "find char", detail: "To next char (include char in selection)"},
+    "::doc::f": { kind: "select", label: "find char", detail: "To next char (include char in selection)", tip: [ "search", "character" ]},
     f: { "modalkeys.search": {
         caseSensitive: true,
         acceptAfter: 1,
@@ -389,7 +408,7 @@ keybindings: {
         selectTillMatch: true,
         wrapAround: true
     }},
-    "::doc::F": { kind: "select", label: "find char back", detail: "To previous character (include char in selection)"},
+    "::doc::F": { kind: "select", label: "find char back", detail: "To previous character (include char in selection)", tip: [ "search", "character" ]},
     F: { "modalkeys.search": {
         caseSensitive: true,
         acceptAfter: 1,
@@ -397,7 +416,7 @@ keybindings: {
         selectTillMatch: true,
         wrapAround: true
     }},
-    "::doc::t": { kind: "select", label: "find char", detail: "To next character (exclude char in selection)"},
+    "::doc::t": { kind: "select", label: "find char", detail: "To next character (exclude char in selection)", tip: [ "search", "character" ]},
     t: { "modalkeys.search": {
         caseSensitive: true,
         acceptAfter: 1,
@@ -406,7 +425,7 @@ keybindings: {
         offset: 'start',
         wrapAround: true
     }},
-    "::doc::T": { kind: "select", label: "find char back", detail: "To previous character (exclude char in selection)"},
+    "::doc::T": { kind: "select", label: "find char back", detail: "To previous character (exclude char in selection)", tip: [ "search", "character" ]},
     T: { "modalkeys.search": {
         caseSensitive: true,
         acceptAfter: 1,
@@ -415,7 +434,7 @@ keybindings: {
         offset: 'end',
         wrapAround: true
     }},
-    "::doc::s": { kind: "select", label: "find char pair", detail: "To next character pair"},
+    "::doc::s": { kind: "select", label: "find char pair", detail: "To next character pair", tip: [ "search", "character" ]},
     s: { "modalkeys.search": {
         caseSensitive: true,
         acceptAfter: 2,
@@ -424,7 +443,7 @@ keybindings: {
         offset: 'start',
         wrapAround: true
     }},
-    "::doc::S": { kind: "select", label: "char pair back", detail: "To previous character pair"},
+    "::doc::S": { kind: "select", label: "char pair back", detail: "To previous character pair", tip: [ "search", "character" ]},
     S: { "modalkeys.search": {
         casSensitive: true,
         acceptAfter: 2,
@@ -433,9 +452,9 @@ keybindings: {
         offset: 'start',
         wrapAround: true
     }},
-    "::doc::;": {kind: "select", label: "→ match", detail: "Repeat search motion forwards (for `f`, `t`, etc...)"},
+    "::doc::;": {kind: "select", label: "→ match", detail: "Repeat search motion forwards (for `f`, `t`, etc...)", tip: [ "search", "iteration" ]},
     ";": { "modalkeys.nextMatch": {}, repeat: "__count" },
-    "::doc:::": {kind: "select", label: "← match", detail: "Repeat search motion backwards (for `f`, `t`, etc...)"},
+    "::doc:::": {kind: "select", label: "← match", detail: "Repeat search motion backwards (for `f`, `t`, etc...)", tip: [ "search", "iteration" ]},
     ":": { "modalkeys.previousMatch": {}, repeat: "__count" },
 
     // ### more complex syntactic selections
@@ -486,7 +505,7 @@ keybindings: {
     "::doc::}": {kind: 'select', label: 'around indent', detail: 'all text at same indent along with the line above and below this (ala c-like synatx)', tip: [ "advanced", "ident" ]},
     "}": "vscode-select-by-indent.select-outer",
 
-    // TODO: this is where I stopped adding commands to `docTips`
+    // TODO: this is where I stopped adding selection commands to `docTips`
     "::doc::u`": {kind: 'select', label: 'inside ``', detail: 'inside first character pair `` (non syntactical, useful inside comments)'},
     "u`": { "modalkeys.selectBetween": {
         from: "`", to: "`",
@@ -610,22 +629,22 @@ keybindings: {
     // ### Actions
 
     // #### Insert/append text
-    "::doc::i": {kind: "mode", label: 'insert', detail: "Switch to insert mode" },
+    "::doc::i": {kind: "mode", label: 'insert', detail: "Switch to insert mode" , tip: [ "enter_text", "insert" ]},
     i: [ "modalkeys.cancelMultipleSelections", "modalkeys.enterInsert" ],
-    "::doc::a": {kind: "mode", label: 'append', detail: "Switch to insert mode, moving cursor to end of current character" },
+    "::doc::a": {kind: "mode", label: 'append', detail: "Switch to insert mode, moving cursor to end of current character" , tip: [ "text", "insert" ]},
     a: [ "modalkeys.cancelMultipleSelections", { if: "__char != ''", then: "cursorRight" }, "modalkeys.enterInsert"],
 
-    "::doc::I": {kind: "mode", label: 'insert start', detail: "Switch to insert mode, moving cursor to start of line" },
+    "::doc::I": {kind: "mode", label: 'insert start', detail: "Switch to insert mode, moving cursor to start of line" , tip: [ "text", "insert" ]},
     I: [
         { "cursorMove": { to: "wrappedLineFirstNonWhitespaceCharacter", select: false } },
         "modalkeys.enterInsert",
     ],
 
-    "::doc::A": {kind: "mode", label: 'append eol', detail: "Switch to insert mode, moving cursor to end of line" },
+    "::doc::A": {kind: "mode", label: 'append eol', detail: "Switch to insert mode, moving cursor to end of line" , tip: [ "text", "insert" ]},
     A: [ { "cursorMove": { to: "wrappedLineEnd", select: false } }, "modalkeys.enterInsert", ],
 
     // #### Text Changes
-    "::doc::c": {kind: "mode", label: 'change', detail: "Delete all selected text and move to insert mode"},
+    "::doc::c": {kind: "mode", label: 'change', detail: "Delete all selected text and move to insert mode", tip: [ "text", "change" ]},
     c: countSelectsLines('down', {
         if: "!__selection.isSingleLine && __selection.end.character == 0 && __selection.start.character == 0",
         // multi-line selection
@@ -652,7 +671,7 @@ keybindings: {
         "modalkeys.enterInsert"
     ]),
 
-    "::doc::C": {kind: "mode", label: 'change to eol', detail: "Delete all text from here to end of line, and switch to insert mode"},
+    "::doc::C": {kind: "mode", label: 'change to eol', detail: "Delete all text from here to end of line, and switch to insert mode", tip: [ "text", "change" ]},
     C: countSelectsLines('up', [
         "modalkeys.cancelMultipleSelections",
         "deleteAllRight",
@@ -664,41 +683,41 @@ keybindings: {
         "modalkeys.enterInsert"
     ]),
 
-    "::doc::gy": {kind: "action", label: 'join', detail: "Remove newline between current and next line"},
+    "::doc::gy": {kind: "action", label: 'join', detail: "Remove newline between current and next line", tip: [ "text", "change" ]},
     "gy": countSelectsLines('down', "editor.action.joinLines"),
 
-    "::doc::`": {kind: "action", label: 'swap', detail: "Swap the style of the current selection or the identifier under the cursor (e.g. from camelCase to snake_case)"},
-    "::doc::`c": {kind: "action", label: 'camel', detail: "Swap style to lower camel case (`camelCase`)"},
+    "::doc::`": {kind: "action", label: 'swap', detail: "Swap the style of the current selection or the identifier under the cursor (e.g. from camelCase to snake_case)", tip: [ "advanced_text", "case" ]},
+    "::doc::`c": {kind: "action", label: 'camel', detail: "Swap style to lower camel case (`camelCase`)", tip: [ "advanced_text", "case" ]},
     "`c": "extension.changeCase.camel",
-    "::doc::`U": {kind: "action", label: 'constant', detail: "Swap style to constant (`IS_CONSTANT`)"},
+    "::doc::`U": {kind: "action", label: 'constant', detail: "Swap style to constant (`IS_CONSTANT`)", tip: [ "advanced_text", "case" ]},
     "`U": "extension.changeCase.constant",
-    "::doc::`.": {kind: "action", label: 'dot', detail: "Swap style to dot case (`dot.case`)"},
+    "::doc::`.": {kind: "action", label: 'dot', detail: "Swap style to dot case (`dot.case`)", tip: [ "advanced_text", "case" ]},
     "`.": "extension.changeCase.dot",
-    "::doc::`-": {kind: "action", label: 'kebab', detail: "Swap style to kebab case (`kebab-case`)"},
+    "::doc::`-": {kind: "action", label: 'kebab', detail: "Swap style to kebab case (`kebab-case`)", tip: [ "advanced_text", "case" ]},
     "`-": "extension.changeCase.kebab",
-    "::doc::`L": {kind: "action", label: 'all lower', detail: "Swap all to lower case"},
+    "::doc::`L": {kind: "action", label: 'all lower', detail: "Swap all to lower case", tip: [ "advanced_text", "case" ]},
     "`L": "extension.changeCase.lower",
-    "::doc::`l": {kind: "action", label: 'first lower', detail: "Swap first letter to lower case"},
+    "::doc::`l": {kind: "action", label: 'first lower', detail: "Swap first letter to lower case", tip: [ "advanced_text", "case" ]},
     "`l": "extension.changeCase.lowerFirst",
-    "::doc::` ": {kind: "action", label: 'spaces', detail: "Swap to spaces (`camelCase` -> `camel case`)"},
+    "::doc::` ": {kind: "action", label: 'spaces', detail: "Swap to spaces (`camelCase` -> `camel case`)", tip: [ "advanced_text", "case" ]},
     "` ": "extension.changeCase.no",
-    "::doc::`C": {kind: "action", label: 'Camel', detail: "Swap to uper camel case (`CamelCase`)"},
+    "::doc::`C": {kind: "action", label: 'Camel', detail: "Swap to uper camel case (`CamelCase`)", tip: [ "advanced_text", "case" ]},
     "`C": "extension.changeCase.pascal",
-    "::doc::`/": {kind: "action", label: 'path', detail: "Swap to 'path' case (`path/case`)"},
+    "::doc::`/": {kind: "action", label: 'path', detail: "Swap to 'path' case (`path/case`)", tip: [ "advanced_text", "case" ]},
     "`/": "extension.changeCase.path",
-    "::doc::`_": {kind: "action", label: 'snake', detail: "Swap to snake case (`snake_case`)"},
+    "::doc::`_": {kind: "action", label: 'snake', detail: "Swap to snake case (`snake_case`)", tip: [ "advanced_text", "case" ]},
     "`_": "extension.changeCase.snake",
-    "::doc::`s": {kind: "action", label: 'swap', detail: "Swap upper and lower case letters"},
+    "::doc::`s": {kind: "action", label: 'swap', detail: "Swap upper and lower case letters", tip: [ "advanced_text", "case" ]},
     "`s": "extension.changeCase.swap",
-    "::doc::`t": {kind: "action", label: 'title', detail: "Swap to title case (all words have first upper case letter)"},
+    "::doc::`t": {kind: "action", label: 'title', detail: "Swap to title case (all words have first upper case letter)", tip: [ "advanced_text", "case" ]},
     "`t": "extension.changeCase.title",
-    "::doc::`Y": {kind: "action", label: 'all upper', detail: "Swap to use all upper case letters"},
+    "::doc::`Y": {kind: "action", label: 'all upper', detail: "Swap to use all upper case letters", tip: [ "advanced_text", "case" ]},
     "`Y": "extension.changeCase.upper",
-    "::doc::`u": {kind: "action", label: 'first upper', detail: "Swap first character to upper case"},
+    "::doc::`u": {kind: "action", label: 'first upper', detail: "Swap first character to upper case", tip: [ "advanced_text", "case" ]},
     "`u": "extension.changeCase.upperFirst",
-    "::doc::``": {kind: "action", label: 'toggle', detail: "Toggle through all possible cases"},
+    "::doc::``": {kind: "action", label: 'toggle', detail: "Toggle through all possible cases", tip: [ "advanced_text", "case" ]},
     "``": "extension.toggleCase",
-    "::doc::~": {kind: "action", label: 'swap char', detail: "Swap case of character under the curser"},
+    "::doc::~": {kind: "action", label: 'swap char', detail: "Swap case of character under the curser", tip: [ "advanced_text", "case" ]},
     "~": [
         "modalkeys.cancelMultipleSelections",
         { "cursorMove": { to: 'right', select: true, value: '__count' } },
@@ -712,7 +731,7 @@ keybindings: {
     ],
 
     // #### Update numerical selections
-    "::doc::=": {kind: "action", label: 'inc #', detail: "Increment a number by 1 (increases increment for subsequent selections)"},
+    "::doc::=": {kind: "action", label: 'inc #', detail: "Increment a number by 1 (increases increment for subsequent selections)", tip: [ "advanced_text", "number" ]},
     "=": [
         {
             if: "__selections.length === 1",
@@ -720,7 +739,7 @@ keybindings: {
             else: "extension.incrementSelection",
         },
     ],
-    "::doc::+": {kind: "action", label: 'dec #', detail: "Decrement a number by 1 (increases increment for subsequent selections)"},
+    "::doc::+": {kind: "action", label: 'dec #', detail: "Decrement a number by 1 (increases increment for subsequent selections)", tip: [ "advanced_text", "number" ]},
     "+": [
         {
             if: "__selections.length === 1",
@@ -728,9 +747,9 @@ keybindings: {
             else: "extension.decrementSelection",
         },
     ],
-    "::doc::g=": {kind: "action", label: 'inc all #', detail: "Increment all numbers by 1"},
+    "::doc::g=": {kind: "action", label: 'inc all #', detail: "Increment all numbers by 1", tip: [ "advanced_text", "number" ]},
     "g=": "editor.emmet.action.incrementNumberByOne",
-    "::doc::g+": {kind: "action", label: 'dec all #', detail: "Decrement all numbers by 1"},
+    "::doc::g+": {kind: "action", label: 'dec all #', detail: "Decrement all numbers by 1", tip: [ "advanced_text", "number" ]},
     "g+": "editor.emmet.action.decrementNumberByOne",
 
     // #### Checkmarks
@@ -742,17 +761,17 @@ keybindings: {
     "ga": "selection-utilities.trimWhitespace",
 
     // #### Brackets
-    "::doc::gx": {kind: "action", label: 'remove pair', detail: "Delete a pairing (e.g. `()`)"},
+    "::doc::gx": {kind: "action", label: 'remove pair', detail: "Delete a pairing (e.g. `()`)", tip: [ "advanced_text", "brackets" ]},
     "::doc::gx[": {kind: "action", label: 'parens/brackets', detail: "Removes pairs that start with `[`, `(` or `{`"},
     "gx[":  "bracketeer.removeBrackets",
-    "::doc::gs": {kind: "action", label: 'swap pair', detail: "Change between different kinds of pairs (e.g. `(` to `{`)"},
+    "::doc::gs": {kind: "action", label: 'swap pair', detail: "Change between different kinds of pairs (e.g. `(` to `{`)", tip: [ "advanced_text", "brackets" ]},
     "::doc::gs[": {kind: "action", label: 'parens/brackets', detail: "Swap between `[`, `(` and `{`"},
     "gs[":  "bracketeer.swapBrackets",
     "::doc::gs'": {kind: "action", label: 'quotes', detail: "Change between different quotes"},
     "gs'":  "bracketeer.swapQuotes",
     "::doc::gx'": {kind: "action", label: 'quotes', detail: "Removes quotes (', \" or `)"},
     "gx'":  "bracketeer.removeQuotes",
-    "::doc::gi": {kind: "action", label: 'insert pair', detail: "Insert a pairing (e.g. ()) around a selection"},
+    "::doc::gi": {kind: "action", label: 'insert pair', detail: "Insert a pairing (e.g. ()) around a selection", tip: [ "advanced_text", "brackets" ]},
     "::doc::gi(": {kind: "action", label: 'paren', detail: "Insert parenthesis around selection"},
     "gi(": [ "modalkeys.enterInsert", { "type": { text: "(" }, }, "modalkeys.enterNormal" ],
     "::doc::gi(": {kind: "action", label: 'paren', detail: "Insert parenthesis around selection"},
@@ -772,13 +791,13 @@ keybindings: {
 
     // #### Clipboard 
 
-    "::doc::d": {kind: "action", label: "delete", detail: "Delete selection and save to paste buffer"},
+    "::doc::d": {kind: "action", label: "delete", detail: "Delete selection and save to paste buffer", tip: [ "text", "delete" ]},
     d: countSelectsLines('down', [
         "editor.action.clipboardCutAction",
         { "modalkeys.enterMode": { mode: "normal" } }, // modalkeys.enterNormal has async issues that cause the entire line to be deleted here
     ]),
 
-    "::doc::D": {kind: "action", label: "delete (eol/up)", detail: "without count: Delete from cursor to end of line; with count: Delete from current line up `count` number of keys."},
+    "::doc::D": {kind: "action", label: "delete (eol/up)", detail: "without count: Delete from cursor to end of line; with count: Delete from current line up `count` number of keys.", tip: [ "text", "delete" ]},
     D: countSelectsLines('up', [
         "modalkeys.cancelMultipleSelections",
         { "cursorMove": { to: "wrappedLineEnd", select: true } },
@@ -789,22 +808,22 @@ keybindings: {
         { "modalkeys.enterMode": { mode: "normal" } }, // modalkeys.enterNormal has async issues that cause the entire line to be deleted here
     ]),
 
-    "::doc::x": {kind: "action", label: "delete char", detail: "delete the character under the cursor"},
+    "::doc::x": {kind: "action", label: "delete char", detail: "delete the character under the cursor", tip: [ "text", "delete" ]},
     x: [
         "modalkeys.cancelMultipleSelections",
         { "cursorMove": { to: "right", select: true } },
         "editor.action.clipboardCutAction",
     ],
 
-    "::doc::,r": {kind: "action", label: "replace char", detail: "replace the character under the cursor"},
+    "::doc::,r": {kind: "action", label: "replace char", detail: "replace the character under the cursor", tip: [ "text", "change" ]},
     ",r": "modalkeys.replaceChar",
 
-    "::doc::y": {kind: "action", label: "copy", detail: "copy selected text to clipboard"},
+    "::doc::y": {kind: "action", label: "copy", detail: "copy selected text to clipboard", tip: [ "text", "copy" ] },
     y: countSelectsLines('down', [
         "editor.action.clipboardCopyAction", "modalkeys.cancelMultipleSelections",
     ]),
 
-    "::doc::Y": {kind: "action", label: "copy (eol/up)", detail: "without a count: copy to end of line; with a count: copy this and the previous N lines"},
+    "::doc::Y": {kind: "action", label: "copy (eol/up)", detail: "without a count: copy to end of line; with a count: copy this and the previous N lines", tip: [ "text", "copy" ]},
     Y: countSelectsLines('up', [
         { "cursorMove": { to: "wrappedLineEnd", select: true } },
         "editor.action.clipboardCopyAction",
@@ -814,7 +833,7 @@ keybindings: {
         "modalkeys.cancelMultipleSelections"
     ]),
 
-    "::doc::v": {kind: "action", label: "paste after", detail: "Paste the next after the cursor/selection"},
+    "::doc::v": {kind: "action", label: "paste after", detail: "Paste the next after the cursor/selection", tip: [ "text", "copy" ]},
     v: [
         {
             if: "!__selection.isEmpty",
@@ -830,7 +849,7 @@ keybindings: {
         "editor.action.clipboardPasteAction",
     ],
 
-    "::doc::V": {kind: "action", label: "paste before", detail: "Paste the next before the cursor/selection"},
+    "::doc::V": {kind: "action", label: "paste before", detail: "Paste the next before the cursor/selection", tip: [ "text", "copy" ]},
     V: [
         {
             if: "!__selection.isEmpty",
@@ -842,14 +861,14 @@ keybindings: {
         "editor.action.clipboardPasteAction",
     ],
 
-    "::doc::gV": {kind: "action", label: "paste replace", detail: "Paste, replacing the selected text"},
+    "::doc::gV": {kind: "action", label: "paste replace", detail: "Paste, replacing the selected text", tip: [ "advanced_text", "copy" ]},
     "gV": "editor.action.clipboardPasteAction",
 
-    "::doc::gv": {kind: "action", label: "paste history", detail: "Paste from clipboard history"},
+    "::doc::gv": {kind: "action", label: "paste history", detail: "Paste from clipboard history", tip: [ "advanced_text", "copy" ]},
     "gv": "clipboard-manager.editor.pickAndPaste" ,
 
 
-    "::doc::,v": {kind: "action", label: "paste after line", detail: "Paste text after current line"},
+    "::doc::,v": {kind: "action", label: "paste after line", detail: "Paste text after current line", tip: [ "advanced_text", "copy" ]},
     ",v": [
         "expandLineSelection",
         "selection-utilities.activeAtEnd",
@@ -857,7 +876,7 @@ keybindings: {
         "editor.action.clipboardPasteAction",
     ],
 
-    "::doc::,V": {kind: "action", label: "paste before line", detail: "Paste text before current line"},
+    "::doc::,V": {kind: "action", label: "paste before line", detail: "Paste text before current line", tip: [ "advanced_text", "copy" ]},
     ",V": [
         "expandLineSelection",
         "selection-utilities.activeAtStart",
@@ -867,35 +886,37 @@ keybindings: {
 
 
     // #### begin line below
-    "::doc::o": {kind: "mode", label: "open below", detail: "open a line below current line and enter insert"},
+    "::doc::o": {kind: "mode", label: "open below", detail: "open a line below current line and enter insert", tip: [ "advanced_text", "insert" ]},
     o: ["editor.action.insertLineAfter", "modalkeys.enterInsert"],
-    "::doc::go": {kind: "action", label: "open below", detail: "open a line below current line"},
+    "::doc::go": {kind: "action", label: "open below", detail: "open a line below current line", tip: [ "advanced_text", "insert" ]},
     go: "editor.action.insertLineAfter",
-    "::doc::visual::o": {kind: "mode", label: "open below", detail: "open a line below current selection and enter insert"},
+    "::doc::visual::o": {kind: "mode", label: "open below", detail: "open a line below current selection and enter insert", tip: [ "advanced_text", "insert" ]},
     "visual::o": "selection-utilities.activeAtEnd",
-    "::doc::O": {kind: "mode", label: "open above", detail: "open a line above current line and enter insert"},
+    "::doc::O": {kind: "mode", label: "open above", detail: "open a line above current line and enter insert", tip: [ "advanced_text", "insert" ]},
     O: [ "editor.action.insertLineBefore", "modalkeys.enterInsert" ],
-    "::doc::gO": {kind: "action", label: "open above", detail: "open a line above current line"},
+    "::doc::gO": {kind: "action", label: "open above", detail: "open a line above current line", tip: [ "advanced_text", "insert" ]},
     gO: "editor.action.insertLineBefore",
-    "::doc::visual::o": {kind: "mode", label: "open before", detail: "open a line above current selection and enter insert"},
+    "::doc::visual::o": {kind: "mode", label: "open before", detail: "open a line above current selection and enter insert", tip: [ "advanced_text", "insert" ]},
     "visual::O": "selection-utilities.activeAtStart",
 
     // #### line indent
-    "::doc::>": {kind: "action", label: "indent", detail: "Indent lines"},
+    "::doc::>": {kind: "action", label: "indent", detail: "Indent lines", tip: [ "advanced_text", "indent"]},
     ">": countSelectsLines('down', "editor.action.indentLines", [
         "editor.action.indentLines", 
         "modalkeys.cancelMultipleSelections"
     ]),
-    "::doc::<": {kind: "action", label: "deindent", detail: "Deindent lines"},
+    "::doc::<": {kind: "action", label: "deindent", detail: "Deindent lines", tip: [ "advanced_text", "indent"]},
     "<": countSelectsLines('down', "editor.action.outdentLines", [
         "editor.action.outdentLines", 
         "modalkeys.cancelMultipleSelections"
     ]),
-    "::doc::g>": {kind: "action", label: "format", detail: "Format code"},
+    "::doc::g>": {kind: "action", label: "format", detail: "Format code", tip: [ "advanced_text", "indent"]},
     "g>": countSelectsLines('down', "editor.action.formatSelection", [
         "editor.action.formatSelection",
         "modalkeys.cancelMultipleSelections"
     ]),
+
+    // TODO: this is where I stopped adding action tips
 
     // ### File/window related
     "::doc::,f": {kind: "window", label: "open file", detail: "Open file using quick open"},

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -81,6 +81,7 @@ export interface Keyhelp{
     kind: string
     detail?: string,
     keys?: IHash<Keyhelp>
+    tip?: string,
 }
 
 export interface Keymodes {

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -454,7 +454,8 @@ function expandEntryBindingsFn(state: { errors: number, sequencesFor: IHash<stri
 
 const overloadCommands = (oldval: Action, newval: Action) => { if(isCommand(oldval)){ return newval } }
 const overloadHelpEntries  = (oldval: Keyhelp, newval: Keyhelp) => { 
-    if(isHelpEntry(oldval)){ return newval } 
+    if((isHelpEntry(oldval) && !newval?.keys)){ return newval } 
+    if(!oldval?.keys && isHelpEntry(newval)){ return newval }
 }
 
 function expandBindings(bindings: any): [Keymodes | undefined, number] {

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -454,8 +454,10 @@ function expandEntryBindingsFn(state: { errors: number, sequencesFor: IHash<stri
 
 const overloadCommands = (oldval: Action, newval: Action) => { if(isCommand(oldval)){ return newval } }
 const overloadHelpEntries  = (oldval: Keyhelp, newval: Keyhelp) => { 
-    if((isHelpEntry(oldval) && !newval?.keys)){ return newval } 
-    if(!oldval?.keys && isHelpEntry(newval)){ return newval }
+    if((oldval?.keys && isHelpEntry(newval)) || (newval?.keys && isHelpEntry(oldval))){
+        return undefined
+    }
+    if(isHelpEntry(oldval)){ return newval } 
 }
 
 function expandBindings(bindings: any): [Keymodes | undefined, number] {
@@ -515,7 +517,7 @@ function isObject(x: any): boolean {
 }
 
 function isHelpEntry(x: any){
-    return x && x.label !== undefined && x.detail !== undefined
+    return x && x?.label !== undefined && x?.kind !== undefined
 }
 /**
  * This checks if a value is a command.

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -12,6 +12,7 @@ import { mergeWith, merge, uniq, cloneDeep } from 'lodash'
 import { IHash } from './util'
 
 import * as vscode from 'vscode'
+import { KeytipProvider } from './keytips'
 /**
  * ## Action Definitions
  *
@@ -194,6 +195,12 @@ export function setOutputChannel(channel: vscode.OutputChannel) {
 export function log(message: string) {
     outputChannel.appendLine(message)
 }
+
+let keyTipState: KeytipProvider
+export function registerKeytips(provider: KeytipProvider){
+    keyTipState = provider
+}
+
 /**
  * ## Updating Configuration from settings.json
  *
@@ -243,8 +250,10 @@ function UpdateKeybindings(config: vscode.WorkspaceConfiguration) {
     if (errors > 0)
         log(`Found ${errors} error${errors > 1 ? "s" : ""}. ` +
             "Keybindings might not work correctly.")
-    else
+    else{
         log("Validation completed successfully.")
+        keyTipState.setKeymodes(rootKeymodes!)
+    }
 }
 
 /**

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -453,7 +453,9 @@ function expandEntryBindingsFn(state: { errors: number, sequencesFor: IHash<stri
 }
 
 const overloadCommands = (oldval: Action, newval: Action) => { if(isCommand(oldval)){ return newval } }
-const overloadHelpEntries  = (oldval: Action, newval: Action) => { if(isHelpEntry(oldval)){ return newval } }
+const overloadHelpEntries  = (oldval: Keyhelp, newval: Keyhelp) => { 
+    if(isHelpEntry(oldval)){ return newval } 
+}
 
 function expandBindings(bindings: any): [Keymodes | undefined, number] {
     let state = {sequencesFor: <IHash<string[]>>{}, errors: 0}
@@ -463,20 +465,21 @@ function expandBindings(bindings: any): [Keymodes | undefined, number] {
     allModes.push('normal', 'visual')
     allModes = uniq(allModes)
     let result: any = {}
-    function resolveAll<T>(x?: IHash<T>){
+    function resolveAll<T>(x: IHash<T> | undefined, overload: any){
         if(!x) return x
         let result = x
         if(x.__all__){
             for(let mode of allModes){
                 if(mode !== '__all__')
-                    result[mode] = mergeWith(cloneDeep(x.__all__), result[mode], overloadCommands)
+                    result[mode] = mergeWith(cloneDeep(x.__all__), result[mode], overload)
+
             }
             delete result.__all__
         }
         return result
     }
-    keymodes.command = resolveAll(keymodes.command)
-    keymodes.help = resolveAll(keymodes.help)
+    keymodes.command = resolveAll(keymodes.command, overloadCommands)
+    keymodes.help = resolveAll(keymodes.help, overloadHelpEntries)
     return [keymodes, state.errors]
 }
 

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -411,7 +411,7 @@ function expandEntryBindingsFn(state: { errors: number, sequencesFor: IHash<stri
                     for(const mode of modes){
                         if(!keymodes.help) keymodes.help = {}
                         keymodes.help[mode] = keymodes.help[mode] === undefined ? obj :
-                            merge(keymodes.help[mode], obj)
+                            mergeWith(keymodes.help[mode], obj, overloadHelpEntries)
                     }
                 }else{
                     if(state.sequencesFor[mode]?.some((oldseq: string) => {
@@ -453,6 +453,7 @@ function expandEntryBindingsFn(state: { errors: number, sequencesFor: IHash<stri
 }
 
 const overloadCommands = (oldval: Action, newval: Action) => { if(isCommand(oldval)){ return newval } }
+const overloadHelpEntries  = (oldval: Action, newval: Action) => { if(isHelpEntry(oldval)){ return newval } }
 
 function expandBindings(bindings: any): [Keymodes | undefined, number] {
     let state = {sequencesFor: <IHash<string[]>>{}, errors: 0}
@@ -507,6 +508,10 @@ function isNumber(x: any): x is number {
  */
 function isObject(x: any): boolean {
     return x && typeof x === "object"
+}
+
+function isHelpEntry(x: any){
+    return x && x.label !== undefined && x.detail !== undefined
 }
 /**
  * This checks if a value is a command.

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -493,8 +493,8 @@ export function onSelectionChanged(e: vscode.TextEditorSelectionChangeEvent){
  */
 async function runActionForKey(key: string, mode: string = keyMode, state: KeyState = keyState) {
     await state.handleKey(key, realMode(mode))
-    docKeymap!.update(state, realMode(keyMode))
-    docKeytips!.update(state, realMode(keyMode))
+    docKeymap?.update(state, realMode(keyMode))
+    docKeytips?.update(state, realMode(keyMode))
     return !state.waitingForKey()
 }
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1366,7 +1366,7 @@ async function importFile(uri: vscode.Uri){
             config.update("keybindings", preset.keybindings, true)
         if(preset.docTips){
             config.update("docTips", preset.docTips, true) 
-            vscode.commands.executeCommand('modalkeys.showTips')
+            // vscode.commands.executeCommand('modalkeys.showTips')
         }
         checkExtensions(preset.extensions)
         if(preset.docKinds){

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,6 +8,7 @@ import * as vscode from 'vscode'
 import * as actions from './actions'
 import * as commands from './commands'
 import * as keymap from './keymap'
+import * as keytips from "./keytips"
 
 /**
  * This method is called when the extension is activated. The activation events
@@ -42,6 +43,7 @@ export function activate(context: vscode.ExtensionContext) {
 		vscode.workspace.onDidChangeConfiguration(e => {
 			actions.updateFromConfig()
 			keymap.updateFromConfig()
+			keytips.updateFromConfig()
 			commands.enterMode('normal')
 		}),
 		vscode.window.onDidChangeActiveTextEditor(commands.restoreEditorMode),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -58,6 +58,7 @@ export function activate(context: vscode.ExtensionContext) {
 	 */
 	actions.updateFromConfig()
 	keymap.updateFromConfig()
+	keytips.updateFromConfig()
 	if (actions.getStartInNormalMode())
         commands.enterMode('normal')
 	else

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,19 +18,21 @@ import * as keymap from './keymap'
  * which means that the extension is activated as soon as VS Code is running.
  */
 export function activate(context: vscode.ExtensionContext) {
-	let keymapState = keymap.register(context)
+	let keymapState = keymap.register(context);
+	let keyTipState = keytips.register(context)
 
 	/**
 	 * The commands are defined in the `package.json` file. We register them
 	 * with function defined in the `commands` module.
 	 */
-	commands.register(context, keymapState)
+	commands.register(context, keymapState, keyTipState)
 	/**
 	 * We create an output channel for diagnostic messages and pass it to the
 	 * `actions` module.
 	 */
 	let channel = vscode.window.createOutputChannel("ModalKeys")
 	actions.setOutputChannel(channel)
+	actions.registerKeytips(keyTipState)
 
 	/**
 	 * Then we subscribe to events we want to react to.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -58,10 +58,7 @@ export function activate(context: vscode.ExtensionContext) {
 	 */
 	actions.updateFromConfig()
 	keymap.updateFromConfig()
-	if (actions.getStartInNormalMode())
-        commands.enterMode('normal')
-	else
-        commands.enterMode('insert')
+	commands.enterMode(actions.getStartMode())
 }
 /**
  * This method is called when your extension is deactivated

--- a/src/keytips.ts
+++ b/src/keytips.ts
@@ -97,17 +97,17 @@ function indexTips(docTips: UserTipGroup[]){
 function userToNode(tipIndex: IHash<UserTipGroup>, element: UserTipNode, mode: string, 
                     keyModes: Keymodes): TipNode {
     if((<UserTipGroup>element)?.entries){
-        console.log("[ModalKeys] UserTipGroup start")
+        // console.log("[ModalKeys] UserTipGroup start")
         let egroup = <UserTipGroup>element;
         console.dir(egroup)
-        console.log("e: "+egroup)
+        // console.log("e: "+egroup)
         let entries = egroup.entries.map(x => {
-            console.log("[ModalKeys] x: ")
+            // console.log("[ModalKeys] x: ")
             console.dir(x)
             return userToNode(tipIndex, x, mode, keyModes)
         })
-        console.log("past userToNode")
-        console.log("e: "+egroup)
+        // console.log("past userToNode")
+        // console.log("e: "+egroup)
         let seeAlso = egroup.more && egroup.more.filter(id => id in tipIndex)
         if(seeAlso){
             let description = seeAlso.map(id => tipIndex[id].title).join(", ")
@@ -120,10 +120,10 @@ function userToNode(tipIndex: IHash<UserTipGroup>, element: UserTipNode, mode: s
                 entries: []
             })
         }
-        console.log("[ModalKeys] UserTipGroup return")
-        console.log("e: "+egroup)
+        // console.log("[ModalKeys] UserTipGroup return")
+        // console.log("e: "+egroup)
         if(!egroup){
-            console.log("[ModalKeys] Bad E!!")
+            // console.log("[ModalKeys] Bad E!!")
         }
         return { 
             title: egroup.title,
@@ -134,7 +134,7 @@ function userToNode(tipIndex: IHash<UserTipGroup>, element: UserTipNode, mode: s
             entries: entries
         }
     }else if((<UserTipItem>element).title){
-        console.log("[ModalKeys] UserTipItem start")
+        // console.log("[ModalKeys] UserTipItem start")
         let e = <UserTipItem>element;
         let keys = findKeys(tipIndex, e.id, keyModes.help && keyModes.help[mode], 
                             mode, keyModes)
@@ -147,7 +147,7 @@ function userToNode(tipIndex: IHash<UserTipGroup>, element: UserTipNode, mode: s
             entries: keys
         }
     }else if((<Keyhelp>element).kind){
-        console.log("[ModalKeys] Keyhelp start")
+        // console.log("[ModalKeys] Keyhelp start")
         let e = <Keyhelp>element;
         return {
             title: e.label,
@@ -157,7 +157,7 @@ function userToNode(tipIndex: IHash<UserTipGroup>, element: UserTipNode, mode: s
             entries: []
         }
     }else{ // if((<UserTipNote>element).note){
-        console.log("[ModalKeys] UserTipNote start")
+        // console.log("[ModalKeys] UserTipNote start")
         let e = <UserTipNote>element;
         let keys = findKeys(tipIndex, e.id, keyModes.help && keyModes.help[mode], mode, keyModes)
         let title: string | vscode.TreeItemLabel = ""

--- a/src/keytips.ts
+++ b/src/keytips.ts
@@ -1,0 +1,124 @@
+import * as vscode from "vscode";
+import { IHash } from './util';
+import { KeyState } from "./actions";
+import { Keymodes } from "./actions"
+
+let extensionUri: vscode.Uri;
+
+interface TipItem {
+    title: string,
+    comment: string,
+    icon?: string,
+    id: string
+}
+
+class TreeTipItem extends vscode.TreeItem {
+    constructor(item: TipItem){ 
+        super(item.title, vscode.TreeItemCollapsibleState.Expanded); 
+        this.description = item.comment;
+        if(item.icon)
+            this.iconPath = new vscode.ThemeIcon(item.icon);
+    }
+}
+
+// TOOD: how to get key name from keyDoc
+class TreeKeyItem extends vscode.TreeItem {
+    constructor(item: KeyDoc){
+        super(item.key)
+        this.description = item.label
+        this.tooltip = item.detail
+        this.iconPath = vscode.Uri.joinPath(extensionUri, "icons", "key.svg");
+    }
+}
+
+interface TipNote {
+    note: string,
+    id: string
+}
+
+class TreeNoteItem extends vscode.TreeItem {
+    constructor(item: TipNote){
+        super("Note")
+        if(!keyDocs[item.id]){
+            vscode.window.showErrorMessage(`Key tip with id \`${item.id}\` not found!` )
+        }
+        this.description = item.note + ": " + keyDocs[item.id].join(", ")
+        this.iconPath = new vscode.ThemeIcon("note")
+    }
+}
+
+interface TipGroup {
+    title: string
+    comment?: string
+    id: string
+    icon?: string
+    entries: TipNode[];
+}
+
+class TreeGroupItem extends vscode.TreeItem {
+    constructor(item: TipGroup){
+        super(item.title, vscode.TreeItemCollapsibleState.Expanded)
+        this.description = item.comment;
+        if(item.icon){
+            this.iconPath = new vscode.ThemeIcon(item.icon);
+        }
+    }
+}
+
+interface KeyDoc {
+    key: string,
+    kind: string,
+    label: string,
+    detail: string,
+    tip: string
+}
+
+type KeyDocs = IHash<KeyDoc[]>
+let keyDocs: KeyDocs = {};
+type TipNode = TipGroup|TipItem|TipNote
+let docTips: TipGroup[] = []
+
+export function register(context: vscode.ExtensionContext) {
+    const treeProvider = new KeytipProvider()
+    vscode.window.registerTreeDataProvider('modalkeys.tipView', treeProvider)
+    extensionUri = context.extensionUri;
+
+    return treeProvider;
+}
+
+export function updateFromConfig(): void {
+    const config = vscode.workspace.getConfiguration("modalkeys")
+    docTips = config.get<TipGroup[]>("docTips", []);
+}
+
+
+export class KeytipProvider implements vscode.TreeDataProvider <TipNode|KeyDoc> {
+    private keymodes: Keymodes;
+    setKeymodes(modes: Keymodes){
+        this.keymodes = modes;
+        // TODO: update doctips here
+    }
+    getChildren(element?: TipNode|KeyDoc) {
+        if(!element){
+            return docTips;
+        }else{
+            let entries = (<TipGroup>element)?.entries
+            if(entries){
+                return entries
+            }else if((<TipItem>element)?.title){
+                return keyDocs[(<TipItem>element).id];
+            }
+        }
+    }
+    getTreeItem(element: TipNode|KeyDoc) {
+        if((<TipGroup>element)?.entries){
+            return new TreeGroupItem(<TipGroup>element)
+        }else if((<TipItem>element).title){
+            return new TreeTipItem(<TipItem>element)
+        }else if((<KeyDoc>element).kind){
+            return new TreeKeyItem(<KeyDoc>element)
+        }else{ // if((<TipNote>element).note){
+            return new TreeNoteItem(<TipNote>element);
+        }
+    }
+}

--- a/src/keytips.ts
+++ b/src/keytips.ts
@@ -52,7 +52,8 @@ function findKeys(tipIndex: IHash<UserTipGroup>, id: string, doc: IHash<Keyhelp>
                 keys.push(userToNode(tipIndex, keydoc, mode, keyModes))
             }
             if(keydoc.keys){
-                keys = keys.concat(findKeys(tipIndex, id, keydoc.keys, mode, keyModes, doc[key].label))
+                keys = keys.concat(findKeys(tipIndex, id, keydoc.keys, mode, keyModes, 
+                                            prefix + key))
             }
         }
     }
@@ -121,8 +122,7 @@ function userToNode(tipIndex: IHash<UserTipGroup>, element: UserTipNode, mode: s
 
 type Keyhelps = IHash<IHash<Keyhelp[]>>
 let keyDocs: Keyhelps = {};
-type TipEntry = TipNode|Keyhelp
-let docTips: IHash<TipGroup[]> = {}
+let docTips: UserTipGroup[] = []
 
 export function register(context: vscode.ExtensionContext) {
     const treeProvider = new KeytipProvider()
@@ -132,9 +132,11 @@ export function register(context: vscode.ExtensionContext) {
     return treeProvider;
 }
 
+// TODO: stopped here; need to figure out how 
+// to use new data types above in the below setup
 export function updateFromConfig(): void {
     const config = vscode.workspace.getConfiguration("modalkeys")
-    let allTips = config.get<TipGroup[]>("docTips", []);
+    let allTips = config.get<UserTipGroup[]>("docTips", []);
     addTips(allTips, keyDocs)
 }
 

--- a/src/keytips.ts
+++ b/src/keytips.ts
@@ -295,7 +295,7 @@ function prefixMatches(prefix: string){
         if(node.prefixes.length === 0){
             return true
         }else{
-            return node.prefixes.some(x => x == prefix)
+            return prefix == "" || node.prefixes.some(x => x == prefix)
         }
     }
 }

--- a/src/keytips.ts
+++ b/src/keytips.ts
@@ -172,7 +172,7 @@ export function register(context: vscode.ExtensionContext) {
     context.subscriptions.push(vscode.commands.registerCommand('modalkeys.nextKeytip', 
                                                                nextKeytip))
     context.subscriptions.push(vscode.commands.registerCommand('modalkeys.previousKeytip', 
-                                                               nextKeytip))
+                                                               prevKeytip))
 
     return treeProvider;
 }
@@ -205,14 +205,13 @@ export async function prevKeytip(){
 
 export async function showKeytip(index: number){
     if(currentTips){
-        await vscode.commands.executeCommand('workbench.actions.treeView.modalkeys.tipView.collapseAll')
         revealAll(currentTips[index], { select: true, focus: false, expand: true })
     }
 }
 
 function revealAll(tip: IndexedTipNode, options: {expand?: boolean | number, focus?: boolean, select?: boolean}){
     for(let entry of tip.entries){
-        revealAll(entry, {expand: true})
+        revealAll(entry, {expand: true, select: false, focus: false})
     }
     treeView.reveal(tip, options)
 }

--- a/src/keytips.ts
+++ b/src/keytips.ts
@@ -230,6 +230,13 @@ export async function prevKeytip(){
 export async function showKeytip(index: number){
     if(currentTips){
         revealAll(currentTips[index], { select: true, focus: false, expand: true })
+    }else{
+        let children = treeProvider.getChildren()
+        if(children.length > 1){
+            revealAll(children[1], { select: true, focus: false, expand: true })
+        }else if(children.length > 0){
+            revealAll(children[0], { select: true, focus: false, expand: true })
+        }
     }
 }
 

--- a/src/keytips.ts
+++ b/src/keytips.ts
@@ -160,14 +160,14 @@ function userToNode(tipIndex: IHash<UserTipGroup>, element: UserTipNode, mode: s
         console.log("[ModalKeys] UserTipNote start")
         let e = <UserTipNote>element;
         let keys = findKeys(tipIndex, e.id, keyModes.help && keyModes.help[mode], mode, keyModes)
-        let title = undefined
-        if(keys.length = 0){
+        let title: string | vscode.TreeItemLabel = ""
+        if(keys.length === 0){
             log("Error reading docTips: missing tip id `"+e.id+"`.")
         }else{
             title = keys[0].title
         }
         return {
-            title: keys[0].title,
+            title,
             icon: new vscode.ThemeIcon('note'),
             description: e.note,
             type: NodeType.Note,
@@ -327,6 +327,7 @@ export class KeytipProvider implements vscode.TreeDataProvider <IndexedTipNode> 
     }
     
     getChildren(element?: IndexedTipNode) {
+        
         if(!element){
             let result = docTips[this.mode].filter(prefixMatches(this.prefix))
             currentTips = result

--- a/src/keytips.ts
+++ b/src/keytips.ts
@@ -342,10 +342,17 @@ export class KeytipProvider implements vscode.TreeDataProvider <IndexedTipNode> 
     
     getChildren(element?: IndexedTipNode) {
         if(!element){
-            currentTips = docTips[this.mode].filter(prefixMatches(this.prefix))
-            return addKeyMode(currentTips, this.mode)
+            let modeTips = docTips[this.mode]
+            if(modeTips){
+                currentTips = docTips[this.mode].filter(prefixMatches(this.prefix))
+                return addKeyMode(currentTips, this.mode)
+            }
+            return []
         }else{
-            return addKeyMode(element.entries.filter(prefixMatches(this.prefix)), this.mode);
+            if(element.entries && element.entries.length > 0){
+                return element.entries.filter(prefixMatches(this.prefix));
+            }
+            return []
         }
     }
 


### PR DESCRIPTION
Remaining tasks:
- [x] Implement `getParent`
- [x] Figure out how to get a `TreeView`
- [x] Use the `reveal` method of `TreeView` to implement a command to collapse everything and then expand the *next* or *previous* entry in the tree by some index.
- [x] what's with the notes not being able to find their keys
- [x] debug tips when search mode contains active search string
- [x] make sure the tips show up even if the tree hasn't been instatiated
      when a call to next/previousKeytip is made
- [x] keys can have different meanings by mode — right now keys are always organized in a given section regardless of mode
- [x] multiple-key commands do not show up until you hit their first key: I think these should be visible
- [ ] this view remains a bit of information overload, how can we improve it? (possible ideas, maybe don't use all)
   - [ ] selecting a section should filter the keys not in that selection (too much clutter/refreshing without this)
   - [ ] keybinding to focus on a given child of a section
   - [ ] allow spec to give tips priority, have options to show "all", "top 5"
   - [ ] have a way to move tips to a "already viewed" section that gets lower priority (this way more advanced tips can show up for more experienced users)
   - [ ] make it possible to filter by a search string
- [ ] show the key-bindings for selecting sections of keytips inline (near mode)
- [ ] add a command to filter keybindings by a string
- [ ] adding numbers to a command filters all keys (it shouldn't)
- [ ] Document all keybindings for Larkin
- [ ] Document all keybindings for Vim
- [ ] make it possible to move tips to a dismissed section (maybe a separate version/PR)
- [ ] make sure faulty or bad tip specification is handled gracefully