### PR TITLE
allow user to set arbitrary start mode

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -61,7 +61,7 @@ they are same as the rest of text in the status bar.
 | `searchStatusColor`| `undefined`               | Status text color when search is active
 | `selectStatusColor`| `undefined`               | Status text color when selection is active in normal mode
 
-## Start in Normal Mode
+## Custom Start Mode
 
-If you want VS Code to be in insert mode when it starts, set the
-`startInNormalMode` setting to `false` (it defaults to `true`).
+If you want VS Code to be in custom mode when it starts, set the
+`startMode` setting to mode name (it defaults to `normal`).

--- a/package.json
+++ b/package.json
@@ -236,10 +236,10 @@
                     "type": "string",
                     "description": "Color of the status bar mode text when selection is active in normal mode (in HTML format)."
                 },
-                "modalkeys.startInNormalMode": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Is editor initially in normal mode?"
+                "modalkeys.startMode": {
+                    "type": "string",
+                    "default": "normal",
+                    "description": "The initial mode for the editor"
                 },
                 "modalkeys.searchMatchBackground": {
                     "type": "string",

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -123,10 +123,9 @@ let normalStatusColor: string | undefined
 let searchStatusColor: string | undefined
 let selectStatusColor: string | undefined
 /**
- * Another thing you can set in config, is whether ModalKeys starts in normal
- * mode.
+ * Another thing you can set in config, is what mode ModalKeys starts in.
  */
-let startInNormalMode: boolean
+let startMode: string
 /**
  * The root of the action configuration is keymap. This defines what key
  * sequences will be run when keys are pressed in normal mode.
@@ -170,8 +169,8 @@ export function getSelectStyles():
     return [ selectCursorStyle, selectStatusText, selectStatusColor ]
 }
 
-export function getStartInNormalMode(): boolean {
-    return startInNormalMode
+export function getStartMode(): string {
+    return startMode
 }
 
 /**
@@ -220,7 +219,7 @@ export function updateFromConfig(): void {
     normalStatusColor = config.get("normalStatusColor") || undefined
     searchStatusColor = config.get("searchStatusColor") || undefined
     selectStatusColor = config.get("selectStatusColor") || undefined
-    startInNormalMode = config.get<boolean>("startInNormalMode", true)
+    startMode = config.get("startMode", "normal")
 }
 /**
  * The following function updates base keymap and select-mode keymap.

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -9,7 +9,7 @@
 
 //#region -c commands.ts imports
 import * as vscode from 'vscode'
-import { KeyState, getSearchStyles, getInsertStyles, getNormalStyles, getSelectStyles, Command, expandOneCommand, IKeyRecording, log as actionLog } from './actions'
+import { KeyState, getSearchStyles, getInsertStyles, getNormalStyles, getSelectStyles, getStartMode, Command, expandOneCommand, IKeyRecording, log as actionLog } from './actions'
 import { IHash } from './util'
 import { TextDecoder } from 'text-encoding'
 import { DocViewProvider } from './keymap'
@@ -598,7 +598,7 @@ export async function enterMode(args: string | EnterModeArgs) {
 
 export async function restoreEditorMode(editor: vscode.TextEditor | undefined){
     if(editor){
-        let newMode = editorModes[editor.document.uri.toString()] || Normal
+        let newMode = editorModes[editor.document.uri.toString()] || getStartMode()
         handleTypeSubscription(newMode)
         if(newMode === Visual){
             keyMode = Normal

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -40,7 +40,7 @@ export function activate(context: vscode.ExtensionContext) {
 		vscode.workspace.onDidChangeConfiguration(e => {
 			actions.updateFromConfig()
 			keymap.updateFromConfig()
-			commands.enterMode('normal')
+			commands.enterMode(actions.getStartMode())
 		}),
 		vscode.window.onDidChangeActiveTextEditor(commands.restoreEditorMode),
 		vscode.window.onDidChangeTextEditorSelection(e => {
@@ -54,10 +54,7 @@ export function activate(context: vscode.ExtensionContext) {
 	 */
 	actions.updateFromConfig()
 	keymap.updateFromConfig()
-	if (actions.getStartInNormalMode())
-        commands.enterMode('normal')
-	else
-        commands.enterMode('insert')
+	commands.enterMode(actions.getStartMode())
 }
 /**
  * This method is called when your extension is deactivated


### PR DESCRIPTION
This would allow users to set arbitrary start mode.
It will replace the current `modalkeys.startInNormalMode` option.

With this, #53 can be implemented by custom normal and visual mode, to escape from the default behavior that visual is implicit by the editor selection status.