### PR TITLE
fix build-docs command error

### DIFF
--- a/docs/index.js
+++ b/docs/index.js
@@ -1,1 +1,1 @@
-import 'highlight.js/styles/github'
+import 'highlight.js/styles/github.css'


### PR DESCRIPTION
At least locally, this fixes the error with the npm `build-docs` / `build-dev-docs` scripts for me. Changing the --public-url to localhost so that it loads the assets from the correct place I was also able to run a local server and view the generated docs. 